### PR TITLE
Fixes #9 Added support for immediate send

### DIFF
--- a/Herald-for-iOS/AppDelegate.swift
+++ b/Herald-for-iOS/AppDelegate.swift
@@ -78,6 +78,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SensorDelegate {
         logger.info(sensor.rawValue + ",didRead=" + didRead.shortName + ",fromTarget=" + fromTarget.description)
     }
     
+    func sensor(_ sensor: SensorType, didReceive: Data, fromTarget: TargetIdentifier) {
+        logger.info(sensor.rawValue + ",didReceive=" + didReceive.base64EncodedString() + ",fromTarget=" + fromTarget.description)
+    }
+    
     func sensor(_ sensor: SensorType, didShare: [PayloadData], fromTarget: TargetIdentifier) {
         let payloads = didShare.map { $0.shortName }
         logger.info(sensor.rawValue + ",didShare=" + payloads.description + ",fromTarget=" + fromTarget.description)

--- a/Herald-for-iOS/AppDelegate.swift
+++ b/Herald-for-iOS/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SensorDelegate {
 
     // Payload data supplier, sensor and contact log
     var payloadDataSupplier: PayloadDataSupplier?
-    var sensor: Sensor?
+    var sensor: SensorArray?
 
     /// Generate unique and consistent device identifier for testing detection and tracking
     private func identifier() -> Int32 {
@@ -38,6 +38,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SensorDelegate {
         sensor = SensorArray(payloadDataSupplier!)
         sensor?.add(delegate: self)
         sensor?.start()
+        
+        // EXAMPLE immediate data send function (note: NOT wrapped with Herald header)
+        //let targetIdentifier: TargetIdentifier? // ... set its value
+        //let success: Bool = sensor!.immediateSend(data: Data(), targetIdentifier!)
         
         return true
     }

--- a/Herald-for-iOS/ViewController.swift
+++ b/Herald-for-iOS/ViewController.swift
@@ -125,6 +125,13 @@ class ViewController: UIViewController, SensorDelegate {
             self.updateDetection()
         }
     }
+    
+    func sensor(_ sensor: SensorType, didReceive: Data, fromTarget: TargetIdentifier) {
+        DispatchQueue.main.async {
+            self.labelDidRead.text = "didReceive: \(didReceive.base64EncodedString()) (\(self.timestamp()))"
+            self.updateDetection()
+        }
+    }
 
     func sensor(_ sensor: SensorType, didShare: [PayloadData], fromTarget: TargetIdentifier) {
         self.didShare += 1

--- a/herald/herald/Sensor/BLE/BLEReceiver.swift
+++ b/herald/herald/Sensor/BLE/BLEReceiver.swift
@@ -111,8 +111,8 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
             return false
         }
         var toSend = Data([UInt8(BLESensorConfiguration.signalCharacteristicActionWriteImmediate)])
-        let length = Int16(data.count)
-        toSend.append([length])
+        var length = Int16(data.count)
+        toSend.append(Data(bytes: &length, count: MemoryLayout<UInt16>.size))
         toSend.append(data)
         peripheral.writeValue(toSend, for: device.signalCharacteristic!, type: .withResponse)
         return true;

--- a/herald/herald/Sensor/BLE/BLEReceiver.swift
+++ b/herald/herald/Sensor/BLE/BLEReceiver.swift
@@ -111,6 +111,8 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
             return false
         }
         var toSend = Data([UInt8(BLESensorConfiguration.signalCharacteristicActionWriteImmediate)])
+        let length = Int16(data.count)
+        toSend.append([length])
         toSend.append(data)
         peripheral.writeValue(toSend, for: device.signalCharacteristic!, type: .withResponse)
         return true;

--- a/herald/herald/Sensor/BLE/BLEReceiver.swift
+++ b/herald/herald/Sensor/BLE/BLEReceiver.swift
@@ -102,6 +102,18 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
         }
     }
     
+    func immediateSend(data: Data, _ targetIdentifier: TargetIdentifier) -> Bool {
+        logger.debug("immediateSend (targetIdentifier=\(targetIdentifier))")
+        let device = database.device(targetIdentifier)
+        logger.debug("immediateSend (peripheral=\(device.identifier))")
+        guard let peripheral = device.peripheral, peripheral.state == .connected else {
+            logger.fault("immediateSend denied, peripheral not connected (peripheral=\(device.identifier))")
+            return false
+        }
+        peripheral.writeValue(data, for: device.payloadCharacteristic!, type: .withResponse)
+        return true;
+    }
+    
     // MARK:- Scan for peripherals and initiate connection if required
     
     /// All work starts from scan loop.

--- a/herald/herald/Sensor/BLE/BLEReceiver.swift
+++ b/herald/herald/Sensor/BLE/BLEReceiver.swift
@@ -110,7 +110,9 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
             logger.fault("immediateSend denied, peripheral not connected (peripheral=\(device.identifier))")
             return false
         }
-        peripheral.writeValue(data, for: device.payloadCharacteristic!, type: .withResponse)
+        var toSend = Data([UInt8(BLESensorConfiguration.signalCharacteristicActionWriteImmediate)])
+        toSend.append(data)
+        peripheral.writeValue(toSend, for: device.signalCharacteristic!, type: .withResponse)
         return true;
     }
     

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -47,6 +47,8 @@ struct BLESensorConfiguration {
     static let signalCharacteristicActionWriteRSSI = UInt8(2)
     /// Signal characteristic action code for write payload, expect 1 byte action code followed by 2 byte little-endian Int16 integer value for payload sharing data length, then payload sharing data
     static let signalCharacteristicActionWritePayloadSharing = UInt8(3)
+    /// Arbitrary immediate write
+    static let signalCharacteristicActionWriteImmediate = UInt8(4)
 }
 
 

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -64,7 +64,7 @@ class ConcreteBLESensor : NSObject, BLESensor, BLEDatabaseDelegate {
     private var delegates: [SensorDelegate] = []
     private let database: BLEDatabase
     private let transmitter: BLETransmitter
-    private let receiver: BLEReceiver
+    private let receiver: ConcreteBLEReceiver
 
     init(_ payloadDataSupplier: PayloadDataSupplier) {
         database = ConcreteBLEDatabase()
@@ -88,6 +88,10 @@ class ConcreteBLESensor : NSObject, BLESensor, BLEDatabaseDelegate {
         delegates.append(delegate)
         transmitter.add(delegate: delegate)
         receiver.add(delegate: delegate)
+    }
+    
+    func immediateSend(data: Data,_ targetIdentifier: TargetIdentifier) -> Bool {
+        return receiver.immediateSend(data:data,targetIdentifier);
     }
     
     // MARK:- BLEDatabaseDelegate

--- a/herald/herald/Sensor/BLE/BLETransmitter.swift
+++ b/herald/herald/Sensor/BLE/BLETransmitter.swift
@@ -339,6 +339,10 @@ class ConcreteBLETransmitter : NSObject, BLETransmitter, CBPeripheralManagerDele
                         } else {
                             logger.fault("didReceiveWrite, invalid request (central=\(targetIdentifier),action=writePayloadSharing)")
                         }
+                    case BLESensorConfiguration.signalCharacteristicActionWriteImmediate:
+                        logger.debug("didReceiveWrite (central=\(targetIdentifier),action=immediateSend)")
+                        let datasubset = data.subdata(in: 1..<data.count)
+                        delegates.forEach { $0.sensor(.BLE, didReceive: datasubset, fromTarget: targetIdentifier) }
                     default:
                         logger.fault("didReceiveWrite (central=\(targetIdentifier),action=unknown,actionCode=\(actionCode))")
                     }

--- a/herald/herald/Sensor/BLE/BLETransmitter.swift
+++ b/herald/herald/Sensor/BLE/BLETransmitter.swift
@@ -272,6 +272,7 @@ class ConcreteBLETransmitter : NSObject, BLETransmitter, CBPeripheralManagerDele
                 if data.count == 0 {
                     // Receiver writes blank data on detection of transmitter to bring iOS transmitter back from suspended state
                     logger.debug("didReceiveWrite (central=\(targetIdentifier),action=wakeTransmitter)")
+                    peripheral.respond(to: request, withResult: .success)
                 } else if let actionCode = data.uint8(0) {
                     switch actionCode {
                     case BLESensorConfiguration.signalCharacteristicActionWritePayload:
@@ -287,14 +288,17 @@ class ConcreteBLETransmitter : NSObject, BLETransmitter, CBPeripheralManagerDele
                             if data.count == (3 + payloadDataCount) {
                                 let payloadData = PayloadData(data.subdata(in: 3..<data.count))
                                 logger.debug("didReceiveWrite -> didRead=\(payloadData.shortName),fromTarget=\(targetIdentifier)")
+                                peripheral.respond(to: request, withResult: .success)
                                 targetDevice.operatingSystem = .android
                                 targetDevice.receiveOnly = true
                                 targetDevice.payloadData = payloadData
                             } else {
                                 logger.fault("didReceiveWrite, invalid payload (central=\(targetIdentifier),action=writePayload)")
+                                peripheral.respond(to: request, withResult: .invalidAttributeValueLength)
                             }
                         } else {
                             logger.fault("didReceiveWrite, invalid request (central=\(targetIdentifier),action=writePayload)")
+                            peripheral.respond(to: request, withResult: .invalidAttributeValueLength)
                         }
                     case BLESensorConfiguration.signalCharacteristicActionWriteRSSI:
                         // Receive-only Android device writing its RSSI to make its proximity known
@@ -305,11 +309,13 @@ class ConcreteBLETransmitter : NSObject, BLETransmitter, CBPeripheralManagerDele
                         if let rssi = data.int16(1) {
                             let proximity = Proximity(unit: .RSSI, value: Double(rssi))
                             logger.debug("didReceiveWrite -> didMeasure=\(proximity.description),fromTarget=\(targetIdentifier)")
+                            peripheral.respond(to: request, withResult: .success)
                             targetDevice.operatingSystem = .android
                             targetDevice.receiveOnly = true
                             targetDevice.rssi = BLE_RSSI(rssi)
                         } else {
                             logger.fault("didReceiveWrite, invalid request (central=\(targetIdentifier),action=writeRSSI)")
+                            peripheral.respond(to: request, withResult: .invalidAttributeValueLength)
                         }
                     case BLESensorConfiguration.signalCharacteristicActionWritePayloadSharing:
                         // Android device sharing detected iOS devices with this iOS device to enable background detection
@@ -323,6 +329,7 @@ class ConcreteBLETransmitter : NSObject, BLETransmitter, CBPeripheralManagerDele
                             if data.count == (5 + payloadDataCount) {
                                 let payloadSharingData = payloadDataSupplier.payload(data.subdata(in: 5..<data.count))
                                 logger.debug("didReceiveWrite -> didShare=\(payloadSharingData.description),fromTarget=\(targetIdentifier)")
+                                peripheral.respond(to: request, withResult: .success)
                                 delegates.forEach { $0.sensor(.BLE, didShare: payloadSharingData, fromTarget: targetIdentifier) }
                                 targetDevice.operatingSystem = .android
                                 targetDevice.rssi = BLE_RSSI(rssi)
@@ -335,19 +342,37 @@ class ConcreteBLETransmitter : NSObject, BLETransmitter, CBPeripheralManagerDele
                                 }
                             } else {
                                 logger.fault("didReceiveWrite, invalid payload (central=\(targetIdentifier),action=writePayloadSharing)")
+                                peripheral.respond(to: request, withResult: .invalidAttributeValueLength)
                             }
                         } else {
                             logger.fault("didReceiveWrite, invalid request (central=\(targetIdentifier),action=writePayloadSharing)")
+                            peripheral.respond(to: request, withResult: .invalidAttributeValueLength)
                         }
                     case BLESensorConfiguration.signalCharacteristicActionWriteImmediate:
+                        // Used for custom app sharing data that is time sensitive. E.g. timing sync data
                         logger.debug("didReceiveWrite (central=\(targetIdentifier),action=immediateSend)")
-                        let datasubset = data.subdata(in: 1..<data.count)
-                        delegates.forEach { $0.sensor(.BLE, didReceive: datasubset, fromTarget: targetIdentifier) }
+                        // immediateSend data format
+                        // 0-0 : actionCode
+                        // 1-2 : data count in bytes (Int16)
+                        // 3.. : data (to be parsed by app - external to payload handling)
+                        if let immediateDataCount = data.int16(1) {
+                            if data.count == (3 + immediateDataCount) {
+                                let datasubset = data.subdata(in: 3..<data.count)
+                                peripheral.respond(to: request, withResult: .success)
+                                delegates.forEach { $0.sensor(.BLE, didReceive: datasubset, fromTarget: targetIdentifier) }
+                            } else {
+                                logger.fault("didReceiveWrite, invalid payload (central=\(targetIdentifier),action=immediateSend)")
+                                peripheral.respond(to: request, withResult: .invalidAttributeValueLength)
+                            }
+                        } else {
+                            logger.fault("didReceiveWrite, invalid request (central=\(targetIdentifier),action=immediateSend)")
+                            peripheral.respond(to: request, withResult: .invalidAttributeValueLength)
+                        }
                     default:
                         logger.fault("didReceiveWrite (central=\(targetIdentifier),action=unknown,actionCode=\(actionCode))")
+                        peripheral.respond(to: request, withResult: .invalidAttributeValueLength)
                     }
                 }
-                peripheral.respond(to: request, withResult: .success)
             } else {
                 peripheral.respond(to: request, withResult: .invalidAttributeValueLength)
             }

--- a/herald/herald/Sensor/Data/ContactLog.swift
+++ b/herald/herald/Sensor/Data/ContactLog.swift
@@ -39,6 +39,10 @@ class ContactLog: NSObject, SensorDelegate {
         textFile.write(timestamp() + "," + sensor.rawValue + "," + csv(fromTarget) + ",,2,,,," + csv(didRead.shortName))
     }
     
+    func sensor(_ sensor: SensorType, didReceive: Data, fromTarget: TargetIdentifier) {
+        // Do nothing
+    }
+    
     func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier) {
         textFile.write(timestamp() + "," + sensor.rawValue + "," + csv(fromTarget) + ",,,3,,," + csv(didMeasure.description))
     }

--- a/herald/herald/Sensor/Data/DetectionLog.swift
+++ b/herald/herald/Sensor/Data/DetectionLog.swift
@@ -62,6 +62,10 @@ class DetectionLog: NSObject, SensorDelegate {
         }
     }
     
+    func sensor(_ sensor: SensorType, didReceive: Data, fromTarget: TargetIdentifier) {
+        // Do nothing
+    }
+    
     func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier) {
     }
     

--- a/herald/herald/Sensor/Data/StatisticsLog.swift
+++ b/herald/herald/Sensor/Data/StatisticsLog.swift
@@ -75,6 +75,9 @@ class StatisticsLog: NSObject, SensorDelegate {
         identifierToPayload[fromTarget] = didRead.shortName
         add(identifier: fromTarget)
     }
+    func sensor(_ sensor: SensorType, didReceive: Data, fromTarget: TargetIdentifier) {
+        // Do nothing
+    }
     
     func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier) {
         add(identifier: fromTarget)

--- a/herald/herald/Sensor/SensorArray.swift
+++ b/herald/herald/Sensor/SensorArray.swift
@@ -14,13 +14,16 @@ public class SensorArray : NSObject, Sensor {
     private var sensorArray: [Sensor] = []
     public let payloadData: PayloadData
     public static let deviceDescription = "\(UIDevice.current.name) (iOS \(UIDevice.current.systemVersion))"
+    
+    private var concreteBle: ConcreteBLESensor?;
 
     public init(_ payloadDataSupplier: PayloadDataSupplier) {
         logger.debug("init")
         // Location sensor is necessary for enabling background BLE advert detection
         // NOT REQUIRED: sensorArray.append(ConcreteGPSSensor(rangeForBeacon: UUID(uuidString:  BLESensorConfiguration.serviceUUID.uuidString)))
         // BLE sensor for detecting and tracking proximity
-        sensorArray.append(ConcreteBLESensor(payloadDataSupplier))
+        concreteBle = ConcreteBLESensor(payloadDataSupplier)
+        sensorArray.append(concreteBle!)
         // Payload data at initiation time for identifying this device in the logs
         payloadData = payloadDataSupplier.payload(PayloadTimestamp())
         super.init()
@@ -31,6 +34,10 @@ public class SensorArray : NSObject, Sensor {
         add(delegate: DetectionLog(filename: "detection.csv", payloadData: payloadData))
         _ = BatteryLog(filename: "battery.csv")
         logger.info("DEVICE (payloadPrefix=\(payloadData.shortName),description=\(SensorArray.deviceDescription))")
+    }
+    
+    public func immediateSend(data: Data, _ targetIdentifier: TargetIdentifier) -> Bool {
+        return concreteBle!.immediateSend(data: data,targetIdentifier);
     }
     
     public func add(delegate: SensorDelegate) {

--- a/herald/herald/Sensor/SensorDelegate.swift
+++ b/herald/herald/Sensor/SensorDelegate.swift
@@ -39,6 +39,7 @@ public extension SensorDelegate {
     func sensor(_ sensor: SensorType, didDetect: TargetIdentifier) {}
     func sensor(_ sensor: SensorType, didRead: PayloadData, fromTarget: TargetIdentifier) {}
     func sensor(_ sensor: SensorType, didShare: [PayloadData], fromTarget: TargetIdentifier) {}
+    func sensor(_ sensor: SensorType, didReceive: Data, fromTarget: TargetIdentifier) {}
     func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier) {}
     func sensor(_ sensor: SensorType, didVisit: Location) {}
     func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier, withPayload: PayloadData) {}

--- a/herald/herald/Sensor/SensorDelegate.swift
+++ b/herald/herald/Sensor/SensorDelegate.swift
@@ -17,6 +17,9 @@ public protocol SensorDelegate {
     
     /// Read payload data of other targets recently acquired by a target, e.g. Android peripheral sharing payload data acquired from nearby iOS peripherals.
     func sensor(_ sensor: SensorType, didShare: [PayloadData], fromTarget: TargetIdentifier)
+    
+    /// Write signal requests - immediate send
+    func sensor(_ sensor: SensorType, didReceive: Data, fromTarget: TargetIdentifier)
 
     /// Measure proximity to target, e.g. a sample of RSSI values from BLE peripheral.
     func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier)


### PR DESCRIPTION
Immediate Send function on Sensor Array
- Sends arbitrary data to a remote device
- Requires that it is connected already
- Does not block for a response
- Receiving end emits didReceivePayload event
- Application's job to introspect the data and ensure it is valid
- Intended to be used to send supplementary (non Herald protocol) messages to a remote device
- May be used in future for other app ideas

Signed-off-by: Adam Fowler <adamfowleruk@gmail.com>