### PR TITLE
Feature 12 : Migrate all BLE SensorDelegate calls to dedicated DispatchQueue

### DIFF
--- a/herald/Herald.xcodeproj/project.pbxproj
+++ b/herald/Herald.xcodeproj/project.pbxproj
@@ -550,6 +550,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 5NRR4P5W72;
 				INFOPLIST_FILE = HeraldTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -567,6 +568,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 5NRR4P5W72;
 				INFOPLIST_FILE = HeraldTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/herald/herald/Sensor/BLE/BLEReceiver.swift
+++ b/herald/herald/Sensor/BLE/BLEReceiver.swift
@@ -34,6 +34,8 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
     private var delegates: [SensorDelegate] = []
     /// Dedicated sequential queue for all beacon transmitter and receiver tasks.
     private let queue: DispatchQueue!
+    /// Dedicated sequential queue for delegate tasks.
+    private let delegateQueue: DispatchQueue
     /// Database of peripherals
     private let database: BLEDatabase
     /// Payload data supplier for parsing shared payloads
@@ -60,8 +62,9 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
     /// operations impacts CoreBluetooth stability. The receiver and transmitter share a common database of devices to enable the transmitter
     /// to register centrals for resolution by the receiver as peripherals to create symmetric connections. The payload data supplier provides
     /// the actual payload data to be transmitted and received via BLE.
-    required init(queue: DispatchQueue, database: BLEDatabase, payloadDataSupplier: PayloadDataSupplier) {
+    required init(queue: DispatchQueue, delegateQueue: DispatchQueue, database: BLEDatabase, payloadDataSupplier: PayloadDataSupplier) {
         self.queue = queue
+        self.delegateQueue = delegateQueue
         self.database = database
         self.payloadDataSupplier = payloadDataSupplier
         super.init()
@@ -568,7 +571,9 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
         // Bluetooth on -> Scan
         if (central.state == .poweredOn) {
             logger.debug("Update state (state=poweredOn))")
-            delegates.forEach({ $0.sensor(.BLE, didUpdateState: .on) })
+            delegateQueue.async {
+                self.delegates.forEach({ $0.sensor(.BLE, didUpdateState: .on) })
+            }
             scan("updateState")
         } else {
             if #available(iOS 10.0, *) {
@@ -592,7 +597,9 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
                         logger.debug("Update state (state=undefined)")
                 }
             }
-            delegates.forEach({ $0.sensor(.BLE, didUpdateState: .off) })
+            delegateQueue.async {
+                self.delegates.forEach({ $0.sensor(.BLE, didUpdateState: .off) })
+            }
         }
     }
     

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -70,8 +70,8 @@ class ConcreteBLESensor : NSObject, BLESensor, BLEDatabaseDelegate {
 
     init(_ payloadDataSupplier: PayloadDataSupplier) {
         database = ConcreteBLEDatabase()
-        transmitter = ConcreteBLETransmitter(queue: sensorQueue, database: database, payloadDataSupplier: payloadDataSupplier)
-        receiver = ConcreteBLEReceiver(queue: sensorQueue, database: database, payloadDataSupplier: payloadDataSupplier)
+        transmitter = ConcreteBLETransmitter(queue: sensorQueue, delegateQueue: delegateQueue, database: database, payloadDataSupplier: payloadDataSupplier)
+        receiver = ConcreteBLEReceiver(queue: sensorQueue, delegateQueue: delegateQueue, database: database, payloadDataSupplier: payloadDataSupplier)
         super.init()
         database.add(delegate: self)
     }


### PR DESCRIPTION
Decoupling of HERALD from APP by using dedicated DispatchQueue for all SensorDelegate calls from BLE to avoid timeout issues.