### PR TITLE
Configurable payload read - Validated

### DIFF
--- a/Herald-for-iOS.xcodeproj/project.pbxproj
+++ b/Herald-for-iOS.xcodeproj/project.pbxproj
@@ -367,7 +367,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5NRR4P5W72;
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
@@ -387,7 +387,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5NRR4P5W72;
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;

--- a/herald/Herald.xcodeproj/project.pbxproj
+++ b/herald/Herald.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		B650151425229D060070F774 /* SimplePayloadDataSupplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B650151325229D060070F774 /* SimplePayloadDataSupplier.swift */; };
 		B650152025229D480070F774 /* Herald.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B637EF50251E55E60072D238 /* Herald.framework */; platformFilter = ios; };
 		B650152925229D760070F774 /* SimplePayloadDataSupplierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B650152825229D760070F774 /* SimplePayloadDataSupplierTests.swift */; };
+		B6C41BE3255951B700F7E9FB /* StatisticsDidReadLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C41BE2255951B700F7E9FB /* StatisticsDidReadLog.swift */; };
 		B6F745F2255713C2003567B7 /* SocialDistance.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F745EF255713C2003567B7 /* SocialDistance.swift */; };
 		B6F745F3255713C2003567B7 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F745F0255713C2003567B7 /* Sample.swift */; };
 		B6F745F4255713C2003567B7 /* Interactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F745F1255713C2003567B7 /* Interactions.swift */; };
@@ -85,6 +86,7 @@
 		B650151325229D060070F774 /* SimplePayloadDataSupplier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SimplePayloadDataSupplier.swift; path = herald/Sensor/Payload/Simple/SimplePayloadDataSupplier.swift; sourceTree = SOURCE_ROOT; };
 		B650151B25229D480070F774 /* HeraldTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HeraldTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B650152825229D760070F774 /* SimplePayloadDataSupplierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePayloadDataSupplierTests.swift; sourceTree = "<group>"; };
+		B6C41BE2255951B700F7E9FB /* StatisticsDidReadLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StatisticsDidReadLog.swift; path = herald/Sensor/Data/StatisticsDidReadLog.swift; sourceTree = SOURCE_ROOT; };
 		B6D8A56E25229F33000E6CC2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B6F745EF255713C2003567B7 /* SocialDistance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocialDistance.swift; sourceTree = "<group>"; };
 		B6F745F0255713C2003567B7 /* Sample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sample.swift; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				B637EF75251E56320072D238 /* SensorLogger.swift */,
 				B637EF76251E56320072D238 /* ContactLog.swift */,
 				B637EF77251E56320072D238 /* StatisticsLog.swift */,
+				B6C41BE2255951B700F7E9FB /* StatisticsDidReadLog.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -375,6 +378,7 @@
 				B6F7460025571475003567B7 /* SimplePayloadDataMatcher.swift in Sources */,
 				B637EF7A251E56320072D238 /* BLEDatabase.swift in Sources */,
 				B637EF79251E56320072D238 /* BLESensor.swift in Sources */,
+				B6C41BE3255951B700F7E9FB /* StatisticsDidReadLog.swift in Sources */,
 				B6F745F82557145E003567B7 /* PayloadDataMatcher.swift in Sources */,
 				B637EF83251E56320072D238 /* BeaconCodes.swift in Sources */,
 				B6F745FF25571475003567B7 /* BloomFilter.swift in Sources */,

--- a/herald/herald/Sensor/BLE/BLEDatabase.swift
+++ b/herald/herald/Sensor/BLE/BLEDatabase.swift
@@ -225,6 +225,10 @@ class BLEDevice : NSObject {
     var timeIntervalSinceLastUpdate: TimeInterval { get {
             Date().timeIntervalSince(lastUpdatedAt)
         }}
+    /// Time interval since last payload data update, this is used to identify devices that require a payload update.
+    var timeIntervalSinceLastPayloadDataUpdate: TimeInterval { get {
+            Date().timeIntervalSince(payloadDataLastUpdatedAt)
+        }}
     /// Time interval since last advert detected, this is used to detect concurrent connection quota and prioritise disconnections
     var timeIntervalSinceLastAdvert: TimeInterval { get {
         Date().timeIntervalSince(lastAdvertAt)

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -36,10 +36,11 @@ struct BLESensorConfiguration {
     /// Maximum number of concurrent BLE connections
     static let concurrentConnectionQuota = 12
     /// Manufacturer data is being used on Android to store pseudo device address
-    static let manufacturerIdForSensor = UInt16(65530);
+    static let manufacturerIdForSensor = UInt16(65530)
     /// Advert refresh time interval on Android devices
-    static let androidAdvertRefreshTimeInterval = TimeInterval.minute * 15;
-
+    static let androidAdvertRefreshTimeInterval = TimeInterval.minute * 15
+    /// Payload update at regular intervals
+    static let payloadDataUpdateTimeInterval = TimeInterval.never
 
     /// Signal characteristic action code for write payload, expect 1 byte action code followed by 2 byte little-endian Int16 integer value for payload data length, then payload data
     static let signalCharacteristicActionWritePayload = UInt8(1)

--- a/herald/herald/Sensor/BLE/BLEUtilities.swift
+++ b/herald/herald/Sensor/BLE/BLEUtilities.swift
@@ -86,6 +86,7 @@ extension CBPeripheralState: CustomStringConvertible {
  Extension to make the time intervals more human readable in code.
  */
 extension TimeInterval {
+    static var never: TimeInterval { get { TimeInterval(Int.max) } }
     static var day: TimeInterval { get { TimeInterval(86400) } }
     static var hour: TimeInterval { get { TimeInterval(3600) } }
     static var minute: TimeInterval { get { TimeInterval(60) } }

--- a/herald/herald/Sensor/Data/ContactLog.swift
+++ b/herald/herald/Sensor/Data/ContactLog.swift
@@ -39,10 +39,6 @@ class ContactLog: NSObject, SensorDelegate {
         textFile.write(timestamp() + "," + sensor.rawValue + "," + csv(fromTarget) + ",,2,,,," + csv(didRead.shortName))
     }
     
-    func sensor(_ sensor: SensorType, didReceive: Data, fromTarget: TargetIdentifier) {
-        // Do nothing
-    }
-    
     func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier) {
         textFile.write(timestamp() + "," + sensor.rawValue + "," + csv(fromTarget) + ",,,3,,," + csv(didMeasure.description))
     }
@@ -57,6 +53,4 @@ class ContactLog: NSObject, SensorDelegate {
     func sensor(_ sensor: SensorType, didVisit: Location) {
         textFile.write(timestamp() + "," + sensor.rawValue + ",,,,,,5," + csv(didVisit.description))
     }
-    
-
 }

--- a/herald/herald/Sensor/Data/DetectionLog.swift
+++ b/herald/herald/Sensor/Data/DetectionLog.swift
@@ -50,9 +50,6 @@ class DetectionLog: NSObject, SensorDelegate {
     
     // MARK:- SensorDelegate
     
-    func sensor(_ sensor: SensorType, didDetect: TargetIdentifier) {
-    }
-    
     func sensor(_ sensor: SensorType, didRead: PayloadData, fromTarget: TargetIdentifier) {
         queue.async {
             if self.payloads.insert(didRead.shortName).inserted {
@@ -60,13 +57,6 @@ class DetectionLog: NSObject, SensorDelegate {
                 self.write()
             }
         }
-    }
-    
-    func sensor(_ sensor: SensorType, didReceive: Data, fromTarget: TargetIdentifier) {
-        // Do nothing
-    }
-    
-    func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier) {
     }
     
     func sensor(_ sensor: SensorType, didShare: [PayloadData], fromTarget: TargetIdentifier) {
@@ -79,9 +69,4 @@ class DetectionLog: NSObject, SensorDelegate {
             }
         }
     }
-    
-    func sensor(_ sensor: SensorType, didVisit: Location) {
-    }
-    
-
 }

--- a/herald/herald/Sensor/Data/StatisticsDidReadLog.swift
+++ b/herald/herald/Sensor/Data/StatisticsDidReadLog.swift
@@ -1,5 +1,5 @@
 //
-//  StatisticsLog.swift
+//  StatisticsDidReadLog.swift
 //
 //  Copyright 2020 VMware, Inc.
 //  SPDX-License-Identifier: MIT
@@ -7,11 +7,10 @@
 
 import Foundation
 
-/// CSV contact log for post event analysis and visualisation
-class StatisticsLog: NSObject, SensorDelegate {
+/// CSV log of didRead calls for post event analysis and visualisation
+class StatisticsDidReadLog: NSObject, SensorDelegate {
     private let textFile: TextFile
     private let payloadData: PayloadData
-    private var identifierToPayload: [TargetIdentifier:String] = [:]
     private var payloadToTime: [String:Date] = [:]
     private var payloadToSample: [String:Sample] = [:]
     
@@ -24,13 +23,6 @@ class StatisticsLog: NSObject, SensorDelegate {
         return TextFile.csv(value)
     }
     
-    private func add(identifier: TargetIdentifier) {
-        guard let payload = identifierToPayload[identifier] else {
-            return
-        }
-        add(payload: payload)
-    }
-
     private func add(payload: String) {
         guard let time = payloadToTime[payload], let sample = payloadToSample[payload] else {
             payloadToTime[payload] = Date()
@@ -69,12 +61,7 @@ class StatisticsLog: NSObject, SensorDelegate {
     // MARK:- SensorDelegate
     
     func sensor(_ sensor: SensorType, didRead: PayloadData, fromTarget: TargetIdentifier) {
-        identifierToPayload[fromTarget] = didRead.shortName
-        add(identifier: fromTarget)
-    }
-    
-    func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier) {
-        add(identifier: fromTarget)
+        add(payload: didRead.shortName)
     }
     
     func sensor(_ sensor: SensorType, didShare: [PayloadData], fromTarget: TargetIdentifier) {

--- a/herald/herald/Sensor/SensorArray.swift
+++ b/herald/herald/Sensor/SensorArray.swift
@@ -20,7 +20,7 @@ public class SensorArray : NSObject, Sensor {
     public init(_ payloadDataSupplier: PayloadDataSupplier) {
         logger.debug("init")
         // Location sensor is necessary for enabling background BLE advert detection
-        // NOT REQUIRED: sensorArray.append(ConcreteGPSSensor(rangeForBeacon: UUID(uuidString:  BLESensorConfiguration.serviceUUID.uuidString)))
+        sensorArray.append(ConcreteGPSSensor(rangeForBeacon: UUID(uuidString:  BLESensorConfiguration.serviceUUID.uuidString)))
         // BLE sensor for detecting and tracking proximity
         concreteBle = ConcreteBLESensor(payloadDataSupplier)
         sensorArray.append(concreteBle!)
@@ -31,6 +31,7 @@ public class SensorArray : NSObject, Sensor {
         // Loggers
         add(delegate: ContactLog(filename: "contacts.csv"))
         add(delegate: StatisticsLog(filename: "statistics.csv", payloadData: payloadData))
+        add(delegate: StatisticsDidReadLog(filename: "statistics_didRead.csv", payloadData: payloadData))
         add(delegate: DetectionLog(filename: "detection.csv", payloadData: payloadData))
         _ = BatteryLog(filename: "battery.csv")
         logger.info("DEVICE (payloadPrefix=\(payloadData.shortName),description=\(SensorArray.deviceDescription))")


### PR DESCRIPTION
- Enables an app to specify payload update frequency, in addition to default HERALD payload reads
- This enables app developer to choose the balance between security (more frequent payload updates reduces continuity and battery life) and performance (less updates increases continuity and battery life)
- Set BLESensorConfiguration.payloadDataUpdateTimeInterval to define minimum update interval
- Set value to TimeInterval.never (default) to disable feature and adopt HERALD approach which minimises payload reads for maximum performance
- Tested on iPhone 6S, iPhone 6 Plus, Google Pixel 2, Samsung J6 (non-advertising), Samsung A20 (frequency address change)
- Test shows small (circa 3%) impact on continuity

Closes #17

Signed-off-by: c19x <support@c19x.org>