### PR TITLE
ImmediateSend + TxPower

### DIFF
--- a/Herald-for-iOS/Base.lproj/Main.storyboard
+++ b/Herald-for-iOS/Base.lproj/Main.storyboard
@@ -104,16 +104,16 @@
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="3JF-ka-MPe" userLabel="didVisitView">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="3JF-ka-MPe" userLabel="didReceiveView">
                                         <rect key="frame" x="331.5" y="2" width="80.5" height="37.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Visit" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AHP-A4-ii0" userLabel="didVisitLabel">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Receive" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AHP-A4-ii0" userLabel="didReceiveLabel">
                                                 <rect key="frame" x="0.0" y="0.0" width="80.5" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zwh-Bh-YA6" userLabel="didVisitCount">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zwh-Bh-YA6" userLabel="didReceiveCount">
                                                 <rect key="frame" x="0.0" y="17" width="80.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
@@ -303,19 +303,36 @@
                                 </subviews>
                                 <edgeInsets key="layoutMargins" top="0.0" left="8" bottom="0.0" right="8"/>
                             </stackView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DETECTION (0)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aMc-Ll-VVc" userLabel="detection">
-                                <rect key="frame" x="20" y="227" width="123.5" height="20.5"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="PAYLOADS" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="TdI-fU-QMV" userLabel="payloads">
-                                <rect key="frame" x="20" y="255.5" width="374" height="548.5"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="mT0-iS-Edp" userLabel="targets">
+                                <rect key="frame" x="0.0" y="227" width="414" height="585"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <color key="textColor" systemColor="labelColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            </textView>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="targetIdentifier" textLabel="Yns-nW-vSg" detailTextLabel="KbA-nd-sCB" style="IBUITableViewCellStyleSubtitle" id="B78-jI-goU" userLabel="target">
+                                        <rect key="frame" x="0.0" y="28" width="414" height="55.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="B78-jI-goU" id="MgX-yT-G7V">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Yns-nW-vSg">
+                                                    <rect key="frame" x="20" y="10" width="33" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="KbA-nd-sCB">
+                                                    <rect key="frame" x="20" y="31.5" width="33" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="txD-W3-4Y5" userLabel="crash">
                                 <rect key="frame" x="73.5" y="812" width="267" height="30"/>
                                 <state key="normal" title="Tap 3 times to crash app in 10 seconds"/>
@@ -324,30 +341,28 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="aMc-Ll-VVc" firstAttribute="top" secondItem="kgS-kc-Z4r" secondAttribute="bottom" constant="8" id="2B2-WW-t62"/>
                             <constraint firstItem="jt7-VE-xfW" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="3Sf-yK-40c"/>
+                            <constraint firstItem="mT0-iS-Edp" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="4wa-uD-seH"/>
                             <constraint firstItem="kgS-kc-Z4r" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="53m-mg-MjR"/>
                             <constraint firstItem="txD-W3-4Y5" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="6fT-av-Ti7"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="kgS-kc-Z4r" secondAttribute="trailing" id="7h4-EF-vCb"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="mT0-iS-Edp" secondAttribute="trailing" id="8c4-6V-RzO"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="KAb-xc-B24" secondAttribute="trailing" id="AAW-RD-O7y"/>
                             <constraint firstItem="kgS-kc-Z4r" firstAttribute="top" secondItem="KAb-xc-B24" secondAttribute="bottom" id="DST-5k-K6n"/>
                             <constraint firstItem="65L-a9-t2p" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="ENO-Tx-iZm"/>
-                            <constraint firstItem="TdI-fU-QMV" firstAttribute="top" secondItem="aMc-Ll-VVc" secondAttribute="bottom" constant="8" symbolic="YES" id="GIu-qh-zaT"/>
                             <constraint firstItem="65L-a9-t2p" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="Ge9-zm-POM"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="aMc-Ll-VVc" secondAttribute="trailing" symbolic="YES" id="Jg1-cA-HQl"/>
+                            <constraint firstItem="txD-W3-4Y5" firstAttribute="top" secondItem="mT0-iS-Edp" secondAttribute="bottom" id="K9G-CE-nH9"/>
                             <constraint firstItem="KAb-xc-B24" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="KNI-oA-t97"/>
+                            <constraint firstItem="mT0-iS-Edp" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="KQI-iY-kLE"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="jt7-VE-xfW" secondAttribute="trailing" symbolic="YES" id="NeW-Tg-AOh"/>
+                            <constraint firstItem="mT0-iS-Edp" firstAttribute="top" secondItem="kgS-kc-Z4r" secondAttribute="bottom" constant="8" symbolic="YES" id="PMP-zm-cNo"/>
                             <constraint firstItem="kUM-Z2-P2r" firstAttribute="leading" secondItem="jt7-VE-xfW" secondAttribute="leading" id="RKR-qe-qMA"/>
-                            <constraint firstItem="txD-W3-4Y5" firstAttribute="top" secondItem="TdI-fU-QMV" secondAttribute="bottom" constant="8" symbolic="YES" id="TGn-Ml-hrw"/>
                             <constraint firstItem="kgS-kc-Z4r" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="WGO-71-VwL"/>
-                            <constraint firstItem="TdI-fU-QMV" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="WTm-Il-8fd"/>
                             <constraint firstItem="65L-a9-t2p" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="Y6L-cG-D7Y"/>
-                            <constraint firstItem="aMc-Ll-VVc" firstAttribute="leading" secondItem="jt7-VE-xfW" secondAttribute="leading" id="dGF-oa-LqV"/>
                             <constraint firstItem="KAb-xc-B24" firstAttribute="top" secondItem="65L-a9-t2p" secondAttribute="bottom" constant="8" id="dRs-Kk-4Eb"/>
                             <constraint firstItem="kUM-Z2-P2r" firstAttribute="top" secondItem="jt7-VE-xfW" secondAttribute="bottom" constant="8" symbolic="YES" id="eJR-aR-bWv"/>
                             <constraint firstItem="KAb-xc-B24" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="fYj-jM-Lgc"/>
                             <constraint firstItem="65L-a9-t2p" firstAttribute="top" secondItem="kUM-Z2-P2r" secondAttribute="bottom" constant="8" id="jOy-F2-fo8"/>
-                            <constraint firstItem="TdI-fU-QMV" firstAttribute="leading" secondItem="jt7-VE-xfW" secondAttribute="leading" id="kfe-RC-3oY"/>
                             <constraint firstItem="jt7-VE-xfW" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="20" id="rEy-Jj-Z7s"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kUM-Z2-P2r" secondAttribute="trailing" symbolic="YES" id="tHP-J3-77k"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="txD-W3-4Y5" secondAttribute="bottom" constant="20" id="wIq-hA-Tfp"/>
@@ -363,13 +378,12 @@
                         <outlet property="buttonSocialMixingScoreUnitM15" destination="BHp-2W-3zM" id="bZp-c6-Swd"/>
                         <outlet property="buttonSocialMixingScoreUnitM30" destination="QrP-BV-wud" id="8pk-FL-sim"/>
                         <outlet property="buttonSocialMixingScoreUnitM5" destination="MDB-K6-hbc" id="u9s-QX-2Nh"/>
-                        <outlet property="labelDetection" destination="aMc-Ll-VVc" id="y7u-dc-r1r"/>
                         <outlet property="labelDevice" destination="jt7-VE-xfW" id="yY6-HA-pxx"/>
                         <outlet property="labelDidDetectCount" destination="AIe-zx-Ujw" id="tGk-6E-5n6"/>
                         <outlet property="labelDidMeasureCount" destination="QMl-v2-7ps" id="lyL-yW-kOv"/>
                         <outlet property="labelDidReadCount" destination="Ktm-6b-w8e" id="b8i-a2-RuZ"/>
+                        <outlet property="labelDidReceiveCount" destination="Zwh-Bh-YA6" id="zfg-Oe-4lA"/>
                         <outlet property="labelDidShareCount" destination="nGc-YW-dQM" id="EW7-lx-wpV"/>
-                        <outlet property="labelDidVisitCount" destination="Zwh-Bh-YA6" id="zfg-Oe-4lA"/>
                         <outlet property="labelPayload" destination="kUM-Z2-P2r" id="Cea-aa-gNs"/>
                         <outlet property="labelSocialMixingScore00" destination="gG9-Ma-gga" id="8Li-Yz-q5F"/>
                         <outlet property="labelSocialMixingScore01" destination="8Li-lp-A7L" id="vXN-PB-b1q"/>
@@ -383,7 +397,7 @@
                         <outlet property="labelSocialMixingScore09" destination="3s5-0h-FGs" id="irB-i6-07a"/>
                         <outlet property="labelSocialMixingScore10" destination="Pbe-8M-Mb4" id="QvJ-KF-eqo"/>
                         <outlet property="labelSocialMixingScore11" destination="he4-5I-bHb" id="ldI-PR-HVX"/>
-                        <outlet property="textViewPayloads" destination="TdI-fU-QMV" id="fvR-oU-2g3"/>
+                        <outlet property="tableViewTargets" destination="mT0-iS-Edp" id="Vdj-oY-qC3"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -392,9 +406,6 @@
         </scene>
     </scenes>
     <resources>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/herald/HeraldTests/SimplePayloadDataSupplierTests.swift
+++ b/herald/HeraldTests/SimplePayloadDataSupplierTests.swift
@@ -234,4 +234,11 @@ class SimplePayloadDataSupplierTests: XCTestCase {
             }
         }
     }
+    
+    func testPayloadData() throws {
+        for i in 0...600 {
+            let payloadData = PayloadData(repeating: 0, count: i)
+            print("\(i) -> \(payloadData.shortName)")
+        }
+    }
 }

--- a/herald/herald/Sensor/Analysis/Interactions.swift
+++ b/herald/herald/Sensor/Analysis/Interactions.swift
@@ -188,8 +188,10 @@ public class Encounter {
         let f0 = dateFormatter.string(from: timestamp)
         let f1 = proximity.value.description
         let f2 = proximity.unit.rawValue
-        let f3 = payload.base64EncodedString()
-        return "\(f0),\(f1),\(f2),\(f3)"
+        let f3 = proximity.calibration?.value.description ?? ""
+        let f4 = proximity.calibration?.unit.rawValue ?? ""
+        let f5 = payload.base64EncodedString()
+        return "\(f0),\(f1),\(f2),\(f3),\(f4),\(f5)"
     }}
     
     /// Create encounter instance from source data
@@ -202,7 +204,7 @@ public class Encounter {
     /// Create encounter instance from log entry
     init?(_ row: String) {
         let fields = row.split(separator: ",")
-        guard fields.count >= 4 else {
+        guard fields.count >= 6 else {
             return nil
         }
         let dateFormatter = DateFormatter()
@@ -217,8 +219,12 @@ public class Encounter {
         guard let proximityUnit = ProximityMeasurementUnit.init(rawValue: String(fields[2])) else {
             return nil
         }
-        self.proximity = Proximity(unit: proximityUnit, value: proximityValue);
-        guard let payload = PayloadData(base64Encoded: String(fields[3])) else {
+        var calibration: Calibration? = nil
+        if let calibrationValue = Double(String(fields[3])), let calibrationUnit = CalibrationMeasurementUnit.init(rawValue: String(fields[4])) {
+            calibration = Calibration(unit: calibrationUnit, value: calibrationValue)
+        }
+        self.proximity = Proximity(unit: proximityUnit, value: proximityValue, calibration: calibration)
+        guard let payload = PayloadData(base64Encoded: String(fields[5])) else {
             return nil
         }
         self.payload = payload

--- a/herald/herald/Sensor/BLE/BLEDatabase.swift
+++ b/herald/herald/Sensor/BLE/BLEDatabase.swift
@@ -200,6 +200,13 @@ class BLEDevice : NSObject {
             lastUpdatedAt = Date()
             delegate.device(self, didUpdate: .txPower)
         }}
+    /// Transmit power as calibration data
+    var calibration: Calibration? { get {
+        guard let txPower = txPower else {
+            return nil
+        }
+        return Calibration(unit: .BLETransmitPower, value: Double(txPower))
+    }}
     /// Track discovered at timestamp, used by taskConnect to prioritise connection when device runs out of concurrent connection capacity
     var lastDiscoveredAt: Date = Date.distantPast
     /// Track connect request at timestamp, used by taskConnect to prioritise connection when device runs out of concurrent connection capacity

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -20,16 +20,19 @@ public struct BLESensorConfiguration {
     /// Service UUID for beacon service. This is a fixed UUID to enable iOS devices to find each other even
     /// in background mode. Android devices will need to find Apple devices first using the manufacturer code
     /// then discover services to identify actual beacons.
-    /// - Service and characteristic UUIDs are V4 UUIDs that have been randomly generated and tested
-    /// for uniqueness by conducting web searches to ensure it returns no results.
-    static let serviceUUID = CBUUID(string: "428132af-4746-42d3-801e-4572d65bfd9b")
+    /// - Generic networking 16-bit UUID
+    static let serviceUUID = CBUUID(string: "1201")
     /// Signaling characteristic for controlling connection between peripheral and central, e.g. keep each other from suspend state
+    /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     static let androidSignalCharacteristicUUID = CBUUID(string: "f617b813-092e-437a-8324-e09a80821a11")
     /// Signaling characteristic for controlling connection between peripheral and central, e.g. keep each other from suspend state
+    /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     static let iosSignalCharacteristicUUID = CBUUID(string: "0eb0d5f2-eae4-4a9a-8af3-a4adb02d4363")
     /// Primary payload characteristic (read) for distributing payload data from peripheral to central, e.g. identity data
+    /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     static let payloadCharacteristicUUID = CBUUID(string: "3e98c0f8-8f05-4829-a121-43e38f8933e7")
     /// Manufacturer data is being used on Android to store pseudo device address
+    /// - Pending update to dedicated ID
     static let manufacturerIdForSensor = UInt16(65530)
 
     // MARK:- BLE signal characteristic action codes

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -124,7 +124,7 @@ class ConcreteBLESensor : NSObject, BLESensor, BLEDatabaseDelegate {
             guard let rssi = device.rssi else {
                 return
             }
-            let proximity = Proximity(unit: .RSSI, value: Double(rssi))
+            let proximity = Proximity(unit: .RSSI, value: Double(rssi), calibration: device.calibration)
             logger.debug("didMeasure (device=\(device.identifier),payloadData=\(device.payloadData?.shortName ?? "nil"),proximity=\(proximity.description))")
             delegateQueue.async {
                 self.delegates.forEach { $0.sensor(.BLE, didMeasure: proximity, fromTarget: device.identifier) }

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -14,18 +14,18 @@ protocol BLESensor : Sensor {
 /// Defines BLE sensor configuration data, e.g. service and characteristic UUIDs
 struct BLESensorConfiguration {
     static let logLevel: SensorLoggerLevel = .debug;
-    /**
-    Service UUID for beacon service. This is a fixed UUID to enable iOS devices to find each other even
-    in background mode. Android devices will need to find Apple devices first using the manufacturer code
-    then discover services to identify actual beacons.
-    */
-    static let serviceUUID = CBUUID(string: "FFFFFFFF-EEEE-DDDD-0000-000000000000")
+    /// Service UUID for beacon service. This is a fixed UUID to enable iOS devices to find each other even
+    /// in background mode. Android devices will need to find Apple devices first using the manufacturer code
+    /// then discover services to identify actual beacons.
+    /// - Service and characteristic UUIDs are V4 UUIDs that have been randomly generated and tested
+    /// for uniqueness by conducting web searches to ensure it returns no results.
+    static let serviceUUID = CBUUID(string: "428132af-4746-42d3-801e-4572d65bfd9b")
     /// Signaling characteristic for controlling connection between peripheral and central, e.g. keep each other from suspend state
-    static let androidSignalCharacteristicUUID = CBUUID(string: "FFFFFFFF-EEEE-DDDD-0000-000000000001")
+    static let androidSignalCharacteristicUUID = CBUUID(string: "f617b813-092e-437a-8324-e09a80821a11")
     /// Signaling characteristic for controlling connection between peripheral and central, e.g. keep each other from suspend state
-    static let iosSignalCharacteristicUUID = CBUUID(string: "FFFFFFFF-EEEE-DDDD-0000-000000000002")
+    static let iosSignalCharacteristicUUID = CBUUID(string: "0eb0d5f2-eae4-4a9a-8af3-a4adb02d4363")
     /// Primary payload characteristic (read) for distributing payload data from peripheral to central, e.g. identity data
-    static let payloadCharacteristicUUID = CBUUID(string: "FFFFFFFF-EEEE-DDDD-0000-000000000003")
+    static let payloadCharacteristicUUID = CBUUID(string: "3e98c0f8-8f05-4829-a121-43e38f8933e7")
     /// Time delay between notifications for subscribers.
     static let notificationDelay = DispatchTimeInterval.seconds(2)
     /// Time delay between advert restart

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -55,6 +55,8 @@ public struct BLESensorConfiguration {
     static let concurrentConnectionQuota = 12
     /// Advert refresh time interval on Android devices
     static let androidAdvertRefreshTimeInterval = TimeInterval.minute * 15
+    /// Herald internal connection expiry timeout
+    static let connectionAttemptTimeout = TimeInterval(8)
     
     // MARK:- App configurable BLE features
 

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -13,8 +13,6 @@ protocol BLESensor : Sensor {
 
 /// Defines BLE sensor configuration data, e.g. service and characteristic UUIDs
 public struct BLESensorConfiguration {
-    static let logLevel: SensorLoggerLevel = .debug;
-    
     // MARK:- BLE service and characteristic UUID, and manufacturer ID
     
     /// Service UUID for beacon service. This is a fixed UUID to enable iOS devices to find each other even
@@ -59,6 +57,9 @@ public struct BLESensorConfiguration {
     
     // MARK:- App configurable BLE features
 
+    /// Log level for BLESensor
+    public static var logLevel: SensorLoggerLevel = .debug;
+    
     /// Payload update at regular intervals, in addition to default HERALD communication process.
     /// - Use this to enable regular payload reads according to app payload lifespan.
     /// - Set to .never to disable this function.

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -18,8 +18,9 @@ public struct BLESensorConfiguration {
     /// Service UUID for beacon service. This is a fixed UUID to enable iOS devices to find each other even
     /// in background mode. Android devices will need to find Apple devices first using the manufacturer code
     /// then discover services to identify actual beacons.
-    /// - Generic networking 16-bit UUID
-    static let serviceUUID = CBUUID(string: "1201")
+    /// - Service and characteristic UUIDs are V4 UUIDs that have been randomly generated and tested
+    /// for uniqueness by conducting web searches to ensure it returns no results.
+    static let serviceUUID = CBUUID(string: "428132af-4746-42d3-801e-4572d65bfd9b")
     /// Signaling characteristic for controlling connection between peripheral and central, e.g. keep each other from suspend state
     /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     static let androidSignalCharacteristicUUID = CBUUID(string: "f617b813-092e-437a-8324-e09a80821a11")

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -12,8 +12,11 @@ protocol BLESensor : Sensor {
 }
 
 /// Defines BLE sensor configuration data, e.g. service and characteristic UUIDs
-struct BLESensorConfiguration {
+public struct BLESensorConfiguration {
     static let logLevel: SensorLoggerLevel = .debug;
+    
+    // MARK:- BLE service and characteristic UUID, and manufacturer ID
+    
     /// Service UUID for beacon service. This is a fixed UUID to enable iOS devices to find each other even
     /// in background mode. Android devices will need to find Apple devices first using the manufacturer code
     /// then discover services to identify actual beacons.
@@ -26,30 +29,39 @@ struct BLESensorConfiguration {
     static let iosSignalCharacteristicUUID = CBUUID(string: "0eb0d5f2-eae4-4a9a-8af3-a4adb02d4363")
     /// Primary payload characteristic (read) for distributing payload data from peripheral to central, e.g. identity data
     static let payloadCharacteristicUUID = CBUUID(string: "3e98c0f8-8f05-4829-a121-43e38f8933e7")
-    /// Time delay between notifications for subscribers.
-    static let notificationDelay = DispatchTimeInterval.seconds(2)
-    /// Time delay between advert restart
-    static let advertRestartTimeInterval = TimeInterval.hour
-    /// Expiry time for shared payloads, to ensure only recently seen payloads are shared
-    /// Must be > payloadSharingTimeInterval to share pending payloads
-    static let payloadSharingExpiryTimeInterval = TimeInterval.minute * 5
-    /// Maximum number of concurrent BLE connections
-    static let concurrentConnectionQuota = 12
     /// Manufacturer data is being used on Android to store pseudo device address
     static let manufacturerIdForSensor = UInt16(65530)
-    /// Advert refresh time interval on Android devices
-    static let androidAdvertRefreshTimeInterval = TimeInterval.minute * 15
-    /// Payload update at regular intervals
-    static let payloadDataUpdateTimeInterval = TimeInterval.never
 
+    // MARK:- BLE signal characteristic action codes
+    
     /// Signal characteristic action code for write payload, expect 1 byte action code followed by 2 byte little-endian Int16 integer value for payload data length, then payload data
     static let signalCharacteristicActionWritePayload = UInt8(1)
     /// Signal characteristic action code for write RSSI, expect 1 byte action code followed by 4 byte little-endian Int32 integer value for RSSI value
     static let signalCharacteristicActionWriteRSSI = UInt8(2)
     /// Signal characteristic action code for write payload, expect 1 byte action code followed by 2 byte little-endian Int16 integer value for payload sharing data length, then payload sharing data
     static let signalCharacteristicActionWritePayloadSharing = UInt8(3)
-    /// Arbitrary immediate write
+    /// Signal characteristic action code for arbitrary immediate write
     static let signalCharacteristicActionWriteImmediate = UInt8(4)
+
+    // MARK:- BLE event timing
+    
+    /// Time delay between notifications for subscribers.
+    static let notificationDelay = DispatchTimeInterval.seconds(2)
+    /// Time delay between advert restart
+    static let advertRestartTimeInterval = TimeInterval.hour
+    /// Maximum number of concurrent BLE connections
+    static let concurrentConnectionQuota = 12
+    /// Advert refresh time interval on Android devices
+    static let androidAdvertRefreshTimeInterval = TimeInterval.minute * 15
+    
+    // MARK:- App configurable BLE features
+
+    /// Payload update at regular intervals, in addition to default HERALD communication process.
+    /// - Use this to enable regular payload reads according to app payload lifespan.
+    /// - Set to .never to disable this function.
+    /// - Payload updates are reported to SensorDelegate as didRead.
+    /// - Setting take immediate effect, no need to restart BLESensor, can also be applied while BLESensor is active.
+    public static var payloadDataUpdateTimeInterval = TimeInterval.never
 }
 
 

--- a/herald/herald/Sensor/BLE/BLETransmitter.swift
+++ b/herald/herald/Sensor/BLE/BLETransmitter.swift
@@ -312,7 +312,7 @@ class ConcreteBLETransmitter : NSObject, BLETransmitter, CBPeripheralManagerDele
                         // 0-0 : actionCode
                         // 1-2 : rssi value (Int16)
                         if let rssi = data.int16(1) {
-                            let proximity = Proximity(unit: .RSSI, value: Double(rssi))
+                            let proximity = Proximity(unit: .RSSI, value: Double(rssi), calibration: targetDevice.calibration)
                             logger.debug("didReceiveWrite -> didMeasure=\(proximity.description),fromTarget=\(targetIdentifier)")
                             peripheral.respond(to: request, withResult: .success)
                             targetDevice.operatingSystem = .android

--- a/herald/herald/Sensor/Data/SensorLogger.swift
+++ b/herald/herald/Sensor/Data/SensorLogger.swift
@@ -21,7 +21,7 @@ protocol SensorLogger {
     func fault(_ message: String)
 }
 
-enum SensorLoggerLevel: String {
+public enum SensorLoggerLevel: String {
     case debug, info, fault
 }
 

--- a/herald/herald/Sensor/PayloadDataSupplier.swift
+++ b/herald/herald/Sensor/PayloadDataSupplier.swift
@@ -45,7 +45,13 @@ public typealias PayloadData = Data
 
 public extension PayloadData {
     var shortName: String {
-        return String(subdata(in: 3..<count-3).base64EncodedString().prefix(6))
+        guard count > 0 else {
+            return ""
+        }
+        guard count > 3 else {
+            return base64EncodedString()
+        }
+        return String(subdata(in: 3..<count).base64EncodedString().prefix(6))
     }
 }
 

--- a/herald/herald/Sensor/SensorDelegate.swift
+++ b/herald/herald/Sensor/SensorDelegate.swift
@@ -81,9 +81,14 @@ public struct Proximity {
     let unit: ProximityMeasurementUnit
     /// Measured value, e.g. raw RSSI value.
     let value: Double
+    /// Calibration data (optional), e.g. transmit power
+    let calibration: Calibration?
     /// Get plain text description of proximity data
     public var description: String { get {
-        unit.rawValue + ":" + value.description
+        guard let calibration = calibration else {
+            return "\(unit.rawValue):\(value.description)"
+        }
+        return "\(unit.rawValue):\(value.description)[\(calibration.description)]"
     }}
 }
 
@@ -93,6 +98,24 @@ public enum ProximityMeasurementUnit : String {
     case RSSI
     /// Roundtrip time, e.g. Audio signal echo time duration as proximity estimator.
     case RTT
+}
+
+/// Calibration data for interpreting proximity value between sensor and target, e.g. Transmit power for BLE.
+public struct Calibration {
+    /// Unit of measurement, e.g. transmit power
+    let unit: CalibrationMeasurementUnit
+    /// Measured value, e.g. transmit power in BLE advert
+    let value: Double
+    /// Get plain text description of calibration data
+    public var description: String { get {
+        unit.rawValue + ":" + value.description
+    }}
+}
+
+/// Measurement unit for calibrating the proximity transmission data values, e.g. BLE transmit power
+public enum CalibrationMeasurementUnit : String {
+    /// Bluetooth transmit power for describing expected RSSI at 1 metre for interpretation of measured RSSI value.
+    case BLETransmitPower
 }
 
 // MARK:- Location data


### PR DESCRIPTION
UI updated to enable on-demand testing of ImmediateSend by tapping on detected device to send message immediately, resulting in increment of didReceive and receive timestamp on target device.

- UI update replaced didVisit (unused) with didReceive
- UI update to present detected devices as list of targets, tap to trigger immediate send
- UUID updated for services and characteristics inline with Android
- TxPower now available as part of calibration data attached to Proximity
- PayloadData fixed against underflow error