### PR TITLE
Fixes #23 - Workaround to iOS peripheral connecting state bug

### DIFF
--- a/herald/herald/Sensor/BLE/BLEDatabase.swift
+++ b/herald/herald/Sensor/BLE/BLEDatabase.swift
@@ -210,6 +210,8 @@ class BLEDevice : NSObject {
             // Reset lastDisconnectedAt
             lastDisconnectedAt = nil
         }}
+    /// Track Herald initiated connection attempts - workaround for iOS peripheral caching incorrect state bug
+    var lastConnectionInitiationAttempt: Date?
     /// Track disconnected at timestamp, used by taskConnect to prioritise connection when device runs out of concurrent connection capacity
     var lastDisconnectedAt: Date?
     /// Last advert timestamp, inferred from payloadDataLastUpdatedAt, payloadSharingDataLastUpdatedAt, rssiLastUpdatedAt

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -30,6 +30,8 @@ struct BLESensorConfiguration {
     static let notificationDelay = DispatchTimeInterval.seconds(2)
     /// Time delay between advert restart
     static let advertRestartTimeInterval = TimeInterval.hour
+    /// Herald internal connection expiry timeout
+    static let connectionAttemptTimeout = TimeInterval(8)
     /// Expiry time for shared payloads, to ensure only recently seen payloads are shared
     /// Must be > payloadSharingTimeInterval to share pending payloads
     static let payloadSharingExpiryTimeInterval = TimeInterval.minute * 5


### PR DESCRIPTION
Workaround added for iOS peripheral state bug
- Added configuration last connect timeout setting (8 seconds)
- Added BLEDevice.lastConnectionInitiationAttempt optional date field
- BLEReceiver.connect function manages this field's state entirely
- Added disconnect if timeout reached
- Only call central.connect once unless we timeout
- Execute action if connected
Not formally tested yet in 8 hour test
Signed-off-by: Adam Fowler <adamfowleruk@gmail.com>