### PR TITLE
Connection timeout

### DIFF
--- a/herald/herald/Sensor/BLE/BLEDatabase.swift
+++ b/herald/herald/Sensor/BLE/BLEDatabase.swift
@@ -216,11 +216,18 @@ class BLEDevice : NSObject {
         didSet {
             // Reset lastDisconnectedAt
             lastDisconnectedAt = nil
+            // Reset lastConnectionInitiationAttempt
+            lastConnectionInitiationAttempt = nil
         }}
     /// Track Herald initiated connection attempts - workaround for iOS peripheral caching incorrect state bug
     var lastConnectionInitiationAttempt: Date?
     /// Track disconnected at timestamp, used by taskConnect to prioritise connection when device runs out of concurrent connection capacity
-    var lastDisconnectedAt: Date?
+    var lastDisconnectedAt: Date? {
+        didSet {
+            // Reset lastConnectionInitiationAttempt
+            lastConnectionInitiationAttempt = nil
+        }
+    }
     /// Last advert timestamp, inferred from payloadDataLastUpdatedAt, payloadSharingDataLastUpdatedAt, rssiLastUpdatedAt
     var lastAdvertAt: Date { get {
             max(createdAt, lastDiscoveredAt, payloadDataLastUpdatedAt, rssiLastUpdatedAt)

--- a/herald/herald/Sensor/BLE/BLEDatabase.swift
+++ b/herald/herald/Sensor/BLE/BLEDatabase.swift
@@ -209,6 +209,8 @@ class BLEDevice : NSObject {
     }}
     /// Track discovered at timestamp, used by taskConnect to prioritise connection when device runs out of concurrent connection capacity
     var lastDiscoveredAt: Date = Date.distantPast
+    /// Track Herald initiated connection attempts - workaround for iOS peripheral caching incorrect state bug
+    var lastConnectionInitiationAttempt: Date?
     /// Track connect request at timestamp, used by taskConnect to prioritise connection when device runs out of concurrent connection capacity
     var lastConnectRequestedAt: Date = Date.distantPast
     /// Track connected at timestamp, used by taskConnect to prioritise connection when device runs out of concurrent connection capacity
@@ -219,8 +221,6 @@ class BLEDevice : NSObject {
             // Reset lastConnectionInitiationAttempt
             lastConnectionInitiationAttempt = nil
         }}
-    /// Track Herald initiated connection attempts - workaround for iOS peripheral caching incorrect state bug
-    var lastConnectionInitiationAttempt: Date?
     /// Track disconnected at timestamp, used by taskConnect to prioritise connection when device runs out of concurrent connection capacity
     var lastDisconnectedAt: Date? {
         didSet {

--- a/herald/herald/Sensor/BLE/BLEReceiver.swift
+++ b/herald/herald/Sensor/BLE/BLEReceiver.swift
@@ -468,6 +468,7 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
                         // Has Herald already initiated a connect attempt?
                         if (Date() > lastAttempt + BLESensorConfiguration.connectionAttemptTimeout) {
                             // If timeout reached, force disconnect
+                            self.logger.fault("connect timeout, force disconnect (source=\(source),device=\(device),elapsed=\(-lastAttempt.timeIntervalSinceNow))")
                             device.lastConnectionInitiationAttempt = nil
                             self.disconnect("connect|" + source, $0)
                         } else {

--- a/herald/herald/Sensor/BLE/BLEReceiver.swift
+++ b/herald/herald/Sensor/BLE/BLEReceiver.swift
@@ -418,31 +418,30 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
     /// This must be kept in sync with deviceHasPendingTask, which is error prone for
     /// code maintenance. An alternative implementation will be introduced in the future.
     private func taskInitiateNextAction(_ source: String, peripheral: CBPeripheral) {
-        let targetIdentifier = TargetIdentifier(peripheral: peripheral)
         let device = database.device(peripheral, delegate: self)
         if device.rssi == nil {
             // 1. RSSI
-            logger.debug("taskInitiateNextAction (goal=rssi,peripheral=\(targetIdentifier))")
+            logger.debug("taskInitiateNextAction (goal=rssi,device=\(device))")
             readRSSI("taskInitiateNextAction|" + source, peripheral)
         } else if device.signalCharacteristic == nil || device.payloadCharacteristic == nil {
             // 2. Characteristics
-            logger.debug("taskInitiateNextAction (goal=characteristics,peripheral=\(targetIdentifier))")
+            logger.debug("taskInitiateNextAction (goal=characteristics,device=\(device))")
             discoverServices("taskInitiateNextAction|" + source, peripheral)
         } else if device.payloadData == nil {
             // 3. Payload
-            logger.debug("taskInitiateNextAction (goal=payload,peripheral=\(targetIdentifier))")
+            logger.debug("taskInitiateNextAction (goal=payload,device=\(device))")
             readPayload("taskInitiateNextAction|" + source, device)
         } else if device.timeIntervalSinceLastPayloadDataUpdate > BLESensorConfiguration.payloadDataUpdateTimeInterval {
             // 4. Payload update
-            logger.debug("taskInitiateNextAction (goal=payloadUpdate,peripheral=\(targetIdentifier),elapsed=\(device.timeIntervalSinceLastPayloadDataUpdate))")
+            logger.debug("taskInitiateNextAction (goal=payloadUpdate,device=\(device),elapsed=\(device.timeIntervalSinceLastPayloadDataUpdate))")
             readPayload("taskInitiateNextAction|" + source, device)
         } else if device.operatingSystem != .ios {
             // 5. Disconnect Android
-            logger.debug("taskInitiateNextAction (goal=disconnect|\(device.operatingSystem.rawValue),peripheral=\(targetIdentifier))")
+            logger.debug("taskInitiateNextAction (goal=disconnect|\(device.operatingSystem.rawValue),device=\(device))")
             disconnect("taskInitiateNextAction|" + source, peripheral)
         } else {
             // 6. Scan
-            logger.debug("taskInitiateNextAction (goal=scan,peripheral=\(targetIdentifier))")
+            logger.debug("taskInitiateNextAction (goal=scan,device=\(device))")
             scheduleScan("taskInitiateNextAction|" + source)
         }
     }

--- a/herald/herald/Sensor/BLE/BLEReceiver.swift
+++ b/herald/herald/Sensor/BLE/BLEReceiver.swift
@@ -469,7 +469,7 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
                             // If timeout reached, force disconnect
                             self.logger.fault("connect, timeout forcing disconnect (source=\(source),device=\(device),elapsed=\(-lastAttempt.timeIntervalSinceNow))")
                             device.lastConnectionInitiationAttempt = nil
-                            self.disconnect("connect|timeout|" + source, $0)
+                            self.queue.async { self.central.cancelPeripheralConnection(peripheral) }
                         } else {
                             // If not timed out yet, keep trying
                             self.logger.debug("connect, retrying (source=\(source),device=\(device),elapsed=\(-lastAttempt.timeIntervalSinceNow))")

--- a/herald/herald/Sensor/BLE/BLEReceiver.swift
+++ b/herald/herald/Sensor/BLE/BLEReceiver.swift
@@ -468,20 +468,21 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
                         // Has Herald already initiated a connect attempt?
                         if (Date() > lastAttempt + BLESensorConfiguration.connectionAttemptTimeout) {
                             // If timeout reached, force disconnect
-                            self.logger.fault("connect timeout, force disconnect (source=\(source),device=\(device),elapsed=\(-lastAttempt.timeIntervalSinceNow))")
+                            self.logger.fault("connect, timeout forcing disconnect (source=\(source),device=\(device),elapsed=\(-lastAttempt.timeIntervalSinceNow))")
                             device.lastConnectionInitiationAttempt = nil
-                            self.disconnect("connect|" + source, $0)
+                            self.disconnect("connect|timeout|" + source, $0)
                         } else {
-                            // If not timed out yet, do nothing
-                            // DO NOTHING
+                            // If not timed out yet, keep trying
+                            self.logger.debug("connect, retrying (source=\(source),device=\(device),elapsed=\(-lastAttempt.timeIntervalSinceNow))")
+                            self.central.connect($0)
                         }
                     } else {
                         // If not, connect now
+                        self.logger.debug("connect, initiation (source=\(source),device=\(device))")
                         device.lastConnectionInitiationAttempt = Date()
                         self.central.connect($0)
                     }
                 } else {
-                    device.lastConnectionInitiationAttempt = nil
                     self.taskInitiateNextAction("connect|" + source, peripheral: $0)
                 }
             }

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -56,7 +56,7 @@ public struct BLESensorConfiguration {
     /// Advert refresh time interval on Android devices
     static let androidAdvertRefreshTimeInterval = TimeInterval.minute * 15
     /// Herald internal connection expiry timeout
-    static let connectionAttemptTimeout = TimeInterval(90)
+    static let connectionAttemptTimeout = TimeInterval(12)
     
     // MARK:- App configurable BLE features
 
@@ -68,7 +68,7 @@ public struct BLESensorConfiguration {
     /// - Set to .never to disable this function.
     /// - Payload updates are reported to SensorDelegate as didRead.
     /// - Setting take immediate effect, no need to restart BLESensor, can also be applied while BLESensor is active.
-    public static var payloadDataUpdateTimeInterval = TimeInterval(30)
+    public static var payloadDataUpdateTimeInterval = TimeInterval.never
 }
 
 

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -56,7 +56,7 @@ public struct BLESensorConfiguration {
     /// Advert refresh time interval on Android devices
     static let androidAdvertRefreshTimeInterval = TimeInterval.minute * 15
     /// Herald internal connection expiry timeout
-    static let connectionAttemptTimeout = TimeInterval(8)
+    static let connectionAttemptTimeout = TimeInterval(90)
     
     // MARK:- App configurable BLE features
 
@@ -68,7 +68,7 @@ public struct BLESensorConfiguration {
     /// - Set to .never to disable this function.
     /// - Payload updates are reported to SensorDelegate as didRead.
     /// - Setting take immediate effect, no need to restart BLESensor, can also be applied while BLESensor is active.
-    public static var payloadDataUpdateTimeInterval = TimeInterval.never
+    public static var payloadDataUpdateTimeInterval = TimeInterval(30)
 }
 
 


### PR DESCRIPTION
- Increased connection timeout from 8s to 90s
- Experiments show 8s connection timeout will caused disconnect regularly with poorly performing Android devices (Pixel 2), especially when there are many devices in the vicinity.
- Test shows connection time over 30s is common for iOS connection to Android, particularly when PayloadUpdate has been enabled at 30s per update.
- Even 60s to connect is not unusual.
- Frequent forced disconnection of Android device will cause Android device BLE stack to become unstable.
- Better to be conservative with forced disconnections for better iOS error recovery with minor impact on continuity, than be too aggressive and end up causing silent BLE stack failures on Android devices.
- Further testing being conducted to confirm 90s is reasonable.
- Logging has been enabled for force disconnections, along with connnection time for analysis.

Signed-off-by: c19x <support@c19x.org>

Closes #29 