### PR TITLE
iOS-iOS regular payload update continuity

### DIFF
--- a/herald/herald/Sensor/BLE/BLEDatabase.swift
+++ b/herald/herald/Sensor/BLE/BLEDatabase.swift
@@ -221,6 +221,8 @@ class BLEDevice : NSObject {
             // Reset lastConnectionInitiationAttempt
             lastConnectionInitiationAttempt = nil
         }}
+    /// Track read payload request at timestamp, used by readPayload to de-duplicate requests from asynchronous calls
+    var lastReadPayloadRequestedAt: Date = Date.distantPast
     /// Track disconnected at timestamp, used by taskConnect to prioritise connection when device runs out of concurrent connection capacity
     var lastDisconnectedAt: Date? {
         didSet {

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -50,7 +50,7 @@ public struct BLESensorConfiguration {
     /// Time delay between notifications for subscribers.
     static let notificationDelay = DispatchTimeInterval.seconds(2)
     /// Time delay between advert restart
-    static let advertRestartTimeInterval = TimeInterval.hour
+    static let advertRestartTimeInterval = TimeInterval.minute * 5
     /// Maximum number of concurrent BLE connections
     static let concurrentConnectionQuota = 12
     /// Advert refresh time interval on Android devices
@@ -68,7 +68,7 @@ public struct BLESensorConfiguration {
     /// - Set to .never to disable this function.
     /// - Payload updates are reported to SensorDelegate as didRead.
     /// - Setting take immediate effect, no need to restart BLESensor, can also be applied while BLESensor is active.
-    public static var payloadDataUpdateTimeInterval = TimeInterval.never
+    public static var payloadDataUpdateTimeInterval = TimeInterval(15)
 }
 
 

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -50,7 +50,7 @@ public struct BLESensorConfiguration {
     /// Time delay between notifications for subscribers.
     static let notificationDelay = DispatchTimeInterval.seconds(2)
     /// Time delay between advert restart
-    static let advertRestartTimeInterval = TimeInterval.hour * 12
+    static let advertRestartTimeInterval = TimeInterval.hour
     /// Maximum number of concurrent BLE connections
     static let concurrentConnectionQuota = 12
     /// Advert refresh time interval on Android devices

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -50,7 +50,7 @@ public struct BLESensorConfiguration {
     /// Time delay between notifications for subscribers.
     static let notificationDelay = DispatchTimeInterval.seconds(2)
     /// Time delay between advert restart
-    static let advertRestartTimeInterval = TimeInterval.minute * 5
+    static let advertRestartTimeInterval = TimeInterval.hour * 12
     /// Maximum number of concurrent BLE connections
     static let concurrentConnectionQuota = 12
     /// Advert refresh time interval on Android devices
@@ -68,7 +68,7 @@ public struct BLESensorConfiguration {
     /// - Set to .never to disable this function.
     /// - Payload updates are reported to SensorDelegate as didRead.
     /// - Setting take immediate effect, no need to restart BLESensor, can also be applied while BLESensor is active.
-    public static var payloadDataUpdateTimeInterval = TimeInterval(15)
+    public static var payloadDataUpdateTimeInterval = TimeInterval.never
 }
 
 


### PR DESCRIPTION
- Regular payload updates between iOS-iOS may stop working after 1hr (1hr 17m in tests)
- Log shows readValue(payloadCharacteristic) is requested, but no response
- Normally resumes after re-discovery, but not guaranteed
- Suspect async BLE calls and duplicate readValue(payloadCharacteristic) calls from async events to be the cause
- Wrapped all peripheral.xxxx calls in queue.async { block }
- De-duplicate readPayload calls by discarding repeated calls within 2 seconds
- Tested on Pixel 2, iPhone 6S, iPhone 6 Plus
- Pending overnight test to confirm fix

Fixes #31 

Signed-off-by: c19x <support@c19x.org>