### PR TITLE
Location sensor and permission mandatory for iOS 14 - Validated

### DIFF
--- a/herald/herald/Sensor/SensorArray.swift
+++ b/herald/herald/Sensor/SensorArray.swift
@@ -20,6 +20,14 @@ public class SensorArray : NSObject, Sensor {
     public init(_ payloadDataSupplier: PayloadDataSupplier) {
         logger.debug("init")
         // Location sensor is necessary for enabling background BLE advert detection
+        // - This is optional in iOS 9.3 to 13, because an Android device can act as a relay,
+        //   but enabling location sensor will enable direct iOS-iOS detection in background.
+        // - This is mandatory in iOS 14, because service discovery will fail for Android and
+        //   iOS devices unless location sensor has been enabled and the user grants access
+        //   to location. Please note, the actual location is not used nor recorded by HERALD.
+        //   This is only necessary to enable iOS-iOS background BLE advert discovery, and
+        //   service discovery, to enable characteristic read / write / notify with other
+        //   iOS and Android devices.
         sensorArray.append(ConcreteGPSSensor(rangeForBeacon: UUID(uuidString:  BLESensorConfiguration.serviceUUID.uuidString)))
         // BLE sensor for detecting and tracking proximity
         concreteBle = ConcreteBLESensor(payloadDataSupplier)


### PR DESCRIPTION
- HERALD on iOS 14 requires location sensor and user granting location permission to enable background BLE operation with other iOS and Android (all versions) devices.
- Inserted comment in SensorArray to highlight this requirement.
- No change to actual code.
- Impact of location permission on iOS 14 was validated with the following combinations of devices
    - iPhone X iOS 14.2 with iPhone X iOS 14.1
         - Location disabled : Detection, RSSI, but no service, no read/write
         - Location enabled  : Fully functional
    - iPhone X iOS 14.2 with iPhone 6S iOS 12
         - Same behaviour
    - iPhone X iOS 14.2 with Pixel 2 Android 10
         - Same behaviour
    - iPhone X iOS 14.2 with Samsung J6 Android 9
         - Same behaviour
    - iPhone X iOS 14.2 with Samsung A20 Android 10
         - Same behaviour
    - iPhone X iOS 14.2 with iPhone X iOS 14.1 and Pixel 2 Android 10
         - Same behaviour
- Enabling location permission by default.

Closed #35 

Signed-off-by: c19x <support@c19x.org>