### PR TITLE
Minor updates to bring in line with Android - Validated

### DIFF
--- a/Herald-for-iOS.xcodeproj/project.pbxproj
+++ b/Herald-for-iOS.xcodeproj/project.pbxproj
@@ -367,7 +367,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Z4G2H2H6CW;
+				DEVELOPMENT_TEAM = "";
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
@@ -387,7 +387,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Z4G2H2H6CW;
+				DEVELOPMENT_TEAM = "";
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;

--- a/Herald-for-iOS/ViewController.swift
+++ b/Herald-for-iOS/ViewController.swift
@@ -286,21 +286,20 @@ class ViewController: UIViewController, SensorDelegate, UITableViewDataSource, U
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "targetIdentifier", for: indexPath)
         let target = targets[indexPath.row]
-        let method = "read" + (target.didShare == nil ? "" : ",share")
-        var didReadTimeInterval: String? = nil
+        var method = "Read"
         if let mean = target.didReadTimeInterval.mean {
-            didReadTimeInterval = String(format: "%.1f", mean)
+            let didReadTimeInterval = String(format: "%.1f", mean)
+            method = "\(method)=\(didReadTimeInterval)s"
         }
-        var didMeasureTimeInterval: String? = nil
         if let mean = target.didMeasureTimeInterval.mean {
-            didMeasureTimeInterval = String(format: "%.1f", mean)
+            let didMeasureTimeInterval = String(format: "%.1f", mean)
+            method = "\(method),Measure=\(didMeasureTimeInterval)s"
         }
-        var timeIntervals: String? = nil
-        if let r = didReadTimeInterval, let m = didMeasureTimeInterval {
-            timeIntervals = " (R:\(r)s,M:\(m)s)"
+        if target.didShare != nil {
+            method = "\(method),Share"
         }
         let didReceive = (target.didReceive == nil ? "" : " (receive \(dateFormatterTime.string(from: target.didReceive!)))")
-        cell.textLabel?.text = "\(target.payloadData.shortName) [\(method)]\(timeIntervals ?? "")"
+        cell.textLabel?.text = "\(target.payloadData.shortName) [\(method)]"
         cell.detailTextLabel?.text = "\(dateFormatter.string(from: target.lastUpdatedAt))\(didReceive)"
         return cell
     }

--- a/herald/herald/Sensor/BLE/BLEReceiver.swift
+++ b/herald/herald/Sensor/BLE/BLEReceiver.swift
@@ -68,7 +68,6 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
         self.database = database
         self.payloadDataSupplier = payloadDataSupplier
         super.init()
-        
         if central == nil {
             self.central = CBCentralManager(delegate: self, queue: queue, options: [
                 CBCentralManagerOptionRestoreIdentifierKey : "Sensor.BLE.ConcreteBLEReceiver",
@@ -85,6 +84,9 @@ class ConcreteBLEReceiver: NSObject, BLEReceiver, BLEDatabaseDelegate, CBCentral
     
     func start() {
         logger.debug("start")
+        guard central != nil else {
+            return
+        }
         // Start scanning
         if central.state == .poweredOn {
             scan("start")

--- a/herald/herald/Sensor/BLE/BLETransmitter.swift
+++ b/herald/herald/Sensor/BLE/BLETransmitter.swift
@@ -75,12 +75,12 @@ class ConcreteBLETransmitter : NSObject, BLETransmitter, CBPeripheralManagerDele
         self.database = database
         self.payloadDataSupplier = payloadDataSupplier
         super.init()
-        
         // Create a peripheral that supports state restoration
         if peripheral == nil {
             self.peripheral = CBPeripheralManager(delegate: self, queue: queue, options: [
                 CBPeripheralManagerOptionRestoreIdentifierKey : "Sensor.BLE.ConcreteBLETransmitter",
-                CBPeripheralManagerOptionShowPowerAlertKey : true
+                // Set this to false to stop iOS from displaying an alert if the app is opened while bluetooth is off.
+                CBPeripheralManagerOptionShowPowerAlertKey : false
             ])
         }
     }
@@ -91,7 +91,9 @@ class ConcreteBLETransmitter : NSObject, BLETransmitter, CBPeripheralManagerDele
     
     func start() {
         logger.debug("start")
-        
+        guard peripheral != nil else {
+            return
+        }
         guard peripheral.state == .poweredOn else {
             logger.fault("start denied, not powered on")
             return

--- a/herald/herald/Sensor/Data/SensorLogger.swift
+++ b/herald/herald/Sensor/Data/SensorLogger.swift
@@ -22,7 +22,7 @@ protocol SensorLogger {
 }
 
 public enum SensorLoggerLevel: String {
-    case debug, info, fault
+    case off, debug, info, fault
 }
 
 class ConcreteSensorLogger: NSObject, SensorLogger {
@@ -44,13 +44,16 @@ class ConcreteSensorLogger: NSObject, SensorLogger {
     }
     
     private func suppress(_ level: SensorLoggerLevel) -> Bool {
+        if (BLESensorConfiguration.logLevel == .off) {
+            return true
+        }
         switch level {
         case .debug:
-            return (BLESensorConfiguration.logLevel == .info || BLESensorConfiguration.logLevel == .fault);
+            return (BLESensorConfiguration.logLevel == .info || BLESensorConfiguration.logLevel == .fault)
         case .info:
-            return (BLESensorConfiguration.logLevel == .fault);
+            return (BLESensorConfiguration.logLevel == .fault)
         default:
-            return false;
+            return false
         }
     }
     
@@ -76,6 +79,8 @@ class ConcreteSensorLogger: NSObject, SensorLogger {
                 os_log("%s", log: log, type: .info, message)
             case .fault:
                 os_log("%s", log: log, type: .fault, message)
+            default:
+                return
             }
             return
         }


### PR DESCRIPTION
- UI update to show read and measure time intervals per device
- Extra check in central and peripheral start() for nil, in line with stop()
- Logger has OFF option to disable logging
- Tested on iPhone 4S, 6S, 6Plus, SE (1st Gen), X (iOS 9.3 - 14.2)
- Tested with Pixel2, Samsung A10, A20, J6, and Note8 (Android 9 - 10)
- Pending results of 8hr+ test

Signed-off-by: c19x <support@c19x.org>