### PR TITLE
Fixes #52. Changed license to Apache-2.0

### DIFF
--- a/Herald-for-iOS.xcodeproj/project.pbxproj
+++ b/Herald-for-iOS.xcodeproj/project.pbxproj
@@ -367,7 +367,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = Z4G2H2H6CW;
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
@@ -387,7 +387,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = Z4G2H2H6CW;
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;

--- a/Herald-for-iOS/AppDelegate.swift
+++ b/Herald-for-iOS/AppDelegate.swift
@@ -2,7 +2,7 @@
 //  AppDelegate.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import UIKit

--- a/Herald-for-iOS/Log.swift
+++ b/Herald-for-iOS/Log.swift
@@ -2,7 +2,7 @@
 //  Log.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/Herald-for-iOS/ViewController.swift
+++ b/Herald-for-iOS/ViewController.swift
@@ -2,7 +2,7 @@
 //  ViewController.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import UIKit

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,14 +1,207 @@
-herald-for-ios 
-Copyright 2020 VMware, Inc.
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-The MIT license (the "License") set forth below applies to all parts of the herald-for-ios project. You may not use this file except in compliance with the License.
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-MIT License
+1. Definitions.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+    "License" shall mean the terms and conditions for use, reproduction, and
+    distribution as defined by Sections 1 through 9 of this document.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+    "Licensor" shall mean the copyright owner or entity authorized by the
+    copyright owner that is granting the License.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    "Legal Entity" shall mean the union of the acting entity and all other
+    entities that control, are controlled by, or are under common control with
+    that entity. For the purposes of this definition, "control" means (i) the
+    power, direct or indirect, to cause the direction or management of such
+    entity, whether by contract or otherwise, or (ii) ownership of
+    fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+    ownership of such entity.
 
+    "You" (or "Your") shall mean an individual or Legal Entity exercising
+    permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation source,
+    and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical transformation
+    or translation of a Source form, including but not limited to compiled
+    object code, generated documentation, and conversions to
+    other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or Object
+    form, made available under the License, as indicated by a copyright notice
+    that is included in or attached to the work (an example is provided in the
+    Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object form,
+    that is based on (or derived from) the Work and for which the editorial
+    revisions, annotations, elaborations, or other modifications represent,
+    as a whole, an original work of authorship. For the purposes of this
+    License, Derivative Works shall not include works that remain separable
+    from, or merely link (or bind by name) to the interfaces of, the Work and
+    Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including the original
+    version of the Work and any modifications or additions to that Work or
+    Derivative Works thereof, that is intentionally submitted to Licensor for
+    inclusion in the Work by the copyright owner or by an individual or
+    Legal Entity authorized to submit on behalf of the copyright owner.
+    For the purposes of this definition, "submitted" means any form of
+    electronic, verbal, or written communication sent to the Licensor or its
+    representatives, including but not limited to communication on electronic
+    mailing lists, source code control systems, and issue tracking systems
+    that are managed by, or on behalf of, the Licensor for the purpose of
+    discussing and improving the Work, but excluding communication that is
+    conspicuously marked or otherwise designated in writing by the copyright
+    owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity on
+    behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2. Grant of Copyright License.
+
+    Subject to the terms and conditions of this License, each Contributor
+    hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+    royalty-free, irrevocable copyright license to reproduce, prepare
+    Derivative Works of, publicly display, publicly perform, sublicense,
+    and distribute the Work and such Derivative Works in
+    Source or Object form.
+
+3. Grant of Patent License.
+
+    Subject to the terms and conditions of this License, each Contributor
+    hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+    royalty-free, irrevocable (except as stated in this section) patent
+    license to make, have made, use, offer to sell, sell, import, and
+    otherwise transfer the Work, where such license applies only to those
+    patent claims licensable by such Contributor that are necessarily
+    infringed by their Contribution(s) alone or by combination of their
+    Contribution(s) with the Work to which such Contribution(s) was submitted.
+    If You institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+    Contribution incorporated within the Work constitutes direct or
+    contributory patent infringement, then any patent licenses granted to
+    You under this License for that Work shall terminate as of the date such
+    litigation is filed.
+
+4. Redistribution.
+
+    You may reproduce and distribute copies of the Work or Derivative Works
+    thereof in any medium, with or without modifications, and in Source or
+    Object form, provided that You meet the following conditions:
+
+    1. You must give any other recipients of the Work or Derivative Works a
+    copy of this License; and
+
+    2. You must cause any modified files to carry prominent notices stating
+    that You changed the files; and
+
+    3. You must retain, in the Source form of any Derivative Works that You
+    distribute, all copyright, patent, trademark, and attribution notices from
+    the Source form of the Work, excluding those notices that do not pertain
+    to any part of the Derivative Works; and
+
+    4. If the Work includes a "NOTICE" text file as part of its distribution,
+    then any Derivative Works that You distribute must include a readable copy
+    of the attribution notices contained within such NOTICE file, excluding
+    those notices that do not pertain to any part of the Derivative Works,
+    in at least one of the following places: within a NOTICE text file
+    distributed as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or, within a
+    display generated by the Derivative Works, if and wherever such
+    third-party notices normally appear. The contents of the NOTICE file are
+    for informational purposes only and do not modify the License.
+    You may add Your own attribution notices within Derivative Works that You
+    distribute, alongside or as an addendum to the NOTICE text from the Work,
+    provided that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and may
+    provide additional or different license terms and conditions for use,
+    reproduction, or distribution of Your modifications, or for any such
+    Derivative Works as a whole, provided Your use, reproduction, and
+    distribution of the Work otherwise complies with the conditions
+    stated in this License.
+
+5. Submission of Contributions.
+
+    Unless You explicitly state otherwise, any Contribution intentionally
+    submitted for inclusion in the Work by You to the Licensor shall be under
+    the terms and conditions of this License, without any additional
+    terms or conditions. Notwithstanding the above, nothing herein shall
+    supersede or modify the terms of any separate license agreement you may
+    have executed with Licensor regarding such Contributions.
+
+6. Trademarks.
+
+    This License does not grant permission to use the trade names, trademarks,
+    service marks, or product names of the Licensor, except as required for
+    reasonable and customary use in describing the origin of the Work and
+    reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+    Unless required by applicable law or agreed to in writing, Licensor
+    provides the Work (and each Contributor provides its Contributions)
+    on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+    either express or implied, including, without limitation, any warranties
+    or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS
+    FOR A PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any risks
+    associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability.
+
+    In no event and under no legal theory, whether in tort
+    (including negligence), contract, or otherwise, unless required by
+    applicable law (such as deliberate and grossly negligent acts) or agreed
+    to in writing, shall any Contributor be liable to You for damages,
+    including any direct, indirect, special, incidental, or consequential
+    damages of any character arising as a result of this License or out of
+    the use or inability to use the Work (including but not limited to damages
+    for loss of goodwill, work stoppage, computer failure or malfunction,
+    or any and all other commercial damages or losses), even if such
+    Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+    While redistributing the Work or Derivative Works thereof, You may choose
+    to offer, and charge a fee for, acceptance of support, warranty,
+    indemnity, or other liability obligations and/or rights consistent with
+    this License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf of any
+    other Contributor, and only if You agree to indemnify, defend, and hold
+    each Contributor harmless for any liability incurred by, or claims
+    asserted against, such Contributor by reason of your accepting any such
+    warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+    To apply the Apache License to your work, attach the following boilerplate
+    notice, with the fields enclosed by brackets "[]" replaced with your own
+    identifying information. (Don't include the brackets!) The text should be
+    enclosed in the appropriate comment syntax for the file format. We also
+    recommend that a file or class name and description of purpose be included
+    on the same "printed page" as the copyright notice for easier
+    identification within third-party archives.
+
+        Copyright 2020 VMware, Inc.
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+        or implied. See the License for the specific language governing
+        permissions and limitations under the License.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,6 +1,6 @@
 herald-for-ios
 Copyright 2020 VMware, Inc. 
 
-This product is licensed to you under the MIT license (the "License").  You may not use this product except in compliance with the MIT License.  
+This product is licensed to you under the Apache-2.0 license (the "License").  You may not use this product except in compliance with the Apache-2.0 License.  
 
 This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Continuous proximity detection across iOS and Android devices in background mode
 
 Copyright 2020 VMware, Inc.
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache2.0-yellow.svg)](https://opensource.org/licenses/Apache-2.0)
 
 See LICENSE.txt and NOTICE.txt for details.
 
@@ -42,13 +42,13 @@ This is a new, original, free and open source cross-platform proximity detection
 - One or more distance measurement per 30 second window for devices within epidemiologically relevant range (8 metres) for accurate infection risk estimation and case isolation; coverage is > 99.5% of 30 second windows for 2 to 3 devices, and 93% - 96% of windows for 9 to 10 devices.
 - RSSI measurements for distance estimation is 98.5% accurate within epidemiologically relevant range (8 metres).
 - Device identification payload agnostic to support both centralised, and decentralised approaches, as well as retrospective integration into existing solutions.
-- MIT license and open source for ease of integration, reuse and transparency.
+- Apache-2.0 licensed and open source for ease of integration, reuse and transparency.
 
 ## Hardware requirements
 
 - Operating system
 
-  - iOS 9.3+, tested up to iOS 13.7.
+  - iOS 9.3+, tested up to iOS 14.2.
   - Android 5.0+, tested up to Android 10.0 (API level 29).
 
 - Hardware
@@ -62,7 +62,7 @@ You will need the following items for evaluation (some of our tested versions in
 
 - Hardware
   - Apple computer (MacBook Pro Late 2013 to Late 2019) running macOS Catalina (10.15.4).
-  - One or more Apple iPhones (iPhone 4S, SE, 5, 6, 7, X, 11) running iOS (9.3 to 13.7).
+  - One or more Apple iPhones (iPhone 4S, SE, 5, 6, 7, X, 11) running iOS (9.3 to 14.2).
   - One or more Android phones (Samsung A10, A20, A70, J6, S10) running Android (8.0 to 10.0).
 - Software
   - Xcode (11.7) for building and deploying the iOS app to test devices.

--- a/herald/HeraldTests/BloomFilterTests.swift
+++ b/herald/HeraldTests/BloomFilterTests.swift
@@ -2,7 +2,7 @@
 //  BloomFilterTests.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import XCTest

--- a/herald/HeraldTests/InteractionsTests.swift
+++ b/herald/HeraldTests/InteractionsTests.swift
@@ -2,7 +2,7 @@
 //  AnalysisTests.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/HeraldTests/SimplePayloadDataMatcherTests.swift
+++ b/herald/HeraldTests/SimplePayloadDataMatcherTests.swift
@@ -2,7 +2,7 @@
 //  SimplePayloadDataMatcherTests.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import XCTest

--- a/herald/HeraldTests/SimplePayloadDataSupplierTests.swift
+++ b/herald/HeraldTests/SimplePayloadDataSupplierTests.swift
@@ -2,7 +2,7 @@
 //  SimplePayloadDataSupplierTests.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import XCTest

--- a/herald/HeraldTests/SocialDistanceTests.swift
+++ b/herald/HeraldTests/SocialDistanceTests.swift
@@ -2,7 +2,7 @@
 //  SocialDistanceTests.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import XCTest

--- a/herald/herald/Sensor/Analysis/Interactions.swift
+++ b/herald/herald/Sensor/Analysis/Interactions.swift
@@ -2,7 +2,7 @@
 //  Interactions.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Analysis/Sample.swift
+++ b/herald/herald/Sensor/Analysis/Sample.swift
@@ -2,7 +2,7 @@
 //  Sample.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Analysis/SocialDistance.swift
+++ b/herald/herald/Sensor/Analysis/SocialDistance.swift
@@ -2,7 +2,7 @@
 //  SocialDistance.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/BLE/BLEDatabase.swift
+++ b/herald/herald/Sensor/BLE/BLEDatabase.swift
@@ -2,7 +2,7 @@
 //  BLEDatabase.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/BLE/BLEReceiver.swift
+++ b/herald/herald/Sensor/BLE/BLEReceiver.swift
@@ -2,7 +2,7 @@
 //  BLEReceiver.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -2,7 +2,7 @@
 //  BLESensor.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/BLE/BLETransmitter.swift
+++ b/herald/herald/Sensor/BLE/BLETransmitter.swift
@@ -2,7 +2,7 @@
 //  BLETransmitter.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/BLE/BLEUtilities.swift
+++ b/herald/herald/Sensor/BLE/BLEUtilities.swift
@@ -2,7 +2,7 @@
 //  BLEUtilities.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Data/BatteryLog.swift
+++ b/herald/herald/Sensor/Data/BatteryLog.swift
@@ -2,7 +2,7 @@
 //  BatteryLog.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import UIKit

--- a/herald/herald/Sensor/Data/ContactLog.swift
+++ b/herald/herald/Sensor/Data/ContactLog.swift
@@ -2,7 +2,7 @@
 //  ContactLog.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Data/DetectionLog.swift
+++ b/herald/herald/Sensor/Data/DetectionLog.swift
@@ -2,7 +2,7 @@
 //  DetectionLog.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Data/SensorLogger.swift
+++ b/herald/herald/Sensor/Data/SensorLogger.swift
@@ -2,7 +2,7 @@
 //  Logger.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Data/StatisticsDidReadLog.swift
+++ b/herald/herald/Sensor/Data/StatisticsDidReadLog.swift
@@ -2,7 +2,7 @@
 //  StatisticsDidReadLog.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Data/StatisticsLog.swift
+++ b/herald/herald/Sensor/Data/StatisticsLog.swift
@@ -2,7 +2,7 @@
 //  StatisticsLog.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Data/TextFile.swift
+++ b/herald/herald/Sensor/Data/TextFile.swift
@@ -2,7 +2,7 @@
 //  TextFile.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Device.swift
+++ b/herald/herald/Sensor/Device.swift
@@ -2,7 +2,7 @@
 //  Device.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/GPS/GPSSensor.swift
+++ b/herald/herald/Sensor/GPS/GPSSensor.swift
@@ -2,7 +2,7 @@
 //  GPSSensor.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Payload/C19X/BeaconCodes.swift
+++ b/herald/herald/Sensor/Payload/C19X/BeaconCodes.swift
@@ -2,7 +2,7 @@
 //  BeaconCodes.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Payload/C19X/C19XPayloadSupplier.swift
+++ b/herald/herald/Sensor/Payload/C19X/C19XPayloadSupplier.swift
@@ -2,7 +2,7 @@
 //  C19XPayloadSupplier.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Payload/C19X/DayCodes.swift
+++ b/herald/herald/Sensor/Payload/C19X/DayCodes.swift
@@ -2,7 +2,7 @@
 //  DayCodes.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Payload/C19X/JavaData.swift
+++ b/herald/herald/Sensor/Payload/C19X/JavaData.swift
@@ -2,7 +2,7 @@
 //  JavaData.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Payload/C19X/SHA.swift
+++ b/herald/herald/Sensor/Payload/C19X/SHA.swift
@@ -2,7 +2,7 @@
 //  SHA.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Payload/Simple/BloomFilter.swift
+++ b/herald/herald/Sensor/Payload/Simple/BloomFilter.swift
@@ -2,7 +2,7 @@
 //  BloomFilter.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Payload/Simple/SimplePayloadDataMatcher.swift
+++ b/herald/herald/Sensor/Payload/Simple/SimplePayloadDataMatcher.swift
@@ -2,7 +2,7 @@
 //  SonarPayloadDataIdentifier.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Payload/Simple/SimplePayloadDataSupplier.swift
+++ b/herald/herald/Sensor/Payload/Simple/SimplePayloadDataSupplier.swift
@@ -2,7 +2,7 @@
 //  SimplePayloadDataSupplier.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Payload/Simple/XXH3.swift
+++ b/herald/herald/Sensor/Payload/Simple/XXH3.swift
@@ -2,7 +2,7 @@
 //  XXH3.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 //  Adapted from xxHash-Swift created by Daisuke T
 //  Copyright © 2019 xxHash-Swift. All rights reserved.

--- a/herald/herald/Sensor/Payload/Sonar/SonarPayloadSupplier.swift
+++ b/herald/herald/Sensor/Payload/Sonar/SonarPayloadSupplier.swift
@@ -2,7 +2,7 @@
 //  SonarPayloadSupplier.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/PayloadDataMatcher.swift
+++ b/herald/herald/Sensor/PayloadDataMatcher.swift
@@ -2,7 +2,7 @@
 //  PayloadDataMatcher.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/PayloadDataSupplier.swift
+++ b/herald/herald/Sensor/PayloadDataSupplier.swift
@@ -2,7 +2,7 @@
 //  PayloadDataSupplier.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/Sensor.swift
+++ b/herald/herald/Sensor/Sensor.swift
@@ -2,7 +2,7 @@
 //  Sensor.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/SensorArray.swift
+++ b/herald/herald/Sensor/SensorArray.swift
@@ -2,7 +2,7 @@
 //  SensorArray.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/Sensor/SensorDelegate.swift
+++ b/herald/herald/Sensor/SensorDelegate.swift
@@ -2,7 +2,7 @@
 //  SensorDelegate.swift
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 import Foundation

--- a/herald/herald/herald.h
+++ b/herald/herald/herald.h
@@ -2,7 +2,7 @@
 //  Herald.h
 //
 //  Copyright 2020 VMware, Inc.
-//  SPDX-License-Identifier: MIT
+//  SPDX-License-Identifier: Apache-2.0
 //
 
 #import <Foundation/Foundation.h>


### PR DESCRIPTION
Changed license to Apache-2.0
- Also added license to files where it was missing
- Completed a clean, full rebuild, and ran tests successfully
Signed-off-by: Adam Fowler <adamfowleruk@gmail.com>