### PR TITLE
Fixes #37. Renamed GPSSensor to AwakeSensor

### DIFF
--- a/Herald-for-iOS/AppDelegate.swift
+++ b/Herald-for-iOS/AppDelegate.swift
@@ -91,8 +91,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, SensorDelegate {
         logger.info(sensor.rawValue + ",didMeasure=" + didMeasure.description + ",fromTarget=" + fromTarget.description)
     }
     
-    func sensor(_ sensor: SensorType, didVisit: Location) {
-        logger.info(sensor.rawValue + ",didVisit=" + didVisit.description)
+    func sensor(_ sensor: SensorType, didVisit: Location?) {
+        logger.info(sensor.rawValue + ",didVisit=" + String(describing: didVisit))
     }
     
     func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier, withPayload: PayloadData) {

--- a/herald/Herald.xcodeproj/project.pbxproj
+++ b/herald/Herald.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		B637EF7B251E56320072D238 /* BLEUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF60251E56320072D238 /* BLEUtilities.swift */; };
 		B637EF7C251E56320072D238 /* BLETransmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF61251E56320072D238 /* BLETransmitter.swift */; };
 		B637EF7D251E56320072D238 /* BLEReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF62251E56320072D238 /* BLEReceiver.swift */; };
-		B637EF7E251E56320072D238 /* GPSSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF64251E56320072D238 /* GPSSensor.swift */; };
+		B637EF7E251E56320072D238 /* AwakeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF64251E56320072D238 /* AwakeSensor.swift */; };
 		B637EF7F251E56320072D238 /* Sensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF65251E56320072D238 /* Sensor.swift */; };
 		B637EF80251E56320072D238 /* SonarPayloadSupplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF68251E56320072D238 /* SonarPayloadSupplier.swift */; };
 		B637EF81251E56320072D238 /* DayCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF6A251E56320072D238 /* DayCodes.swift */; };
@@ -68,7 +68,7 @@
 		B637EF60251E56320072D238 /* BLEUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BLEUtilities.swift; sourceTree = "<group>"; };
 		B637EF61251E56320072D238 /* BLETransmitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BLETransmitter.swift; sourceTree = "<group>"; };
 		B637EF62251E56320072D238 /* BLEReceiver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BLEReceiver.swift; sourceTree = "<group>"; };
-		B637EF64251E56320072D238 /* GPSSensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GPSSensor.swift; sourceTree = "<group>"; };
+		B637EF64251E56320072D238 /* AwakeSensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AwakeSensor.swift; sourceTree = "<group>"; };
 		B637EF65251E56320072D238 /* Sensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sensor.swift; sourceTree = "<group>"; };
 		B637EF68251E56320072D238 /* SonarPayloadSupplier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SonarPayloadSupplier.swift; sourceTree = "<group>"; };
 		B637EF6A251E56320072D238 /* DayCodes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DayCodes.swift; sourceTree = "<group>"; };
@@ -155,7 +155,7 @@
 			children = (
 				B6F745EE255713C2003567B7 /* Analysis */,
 				B637EF5D251E56320072D238 /* BLE */,
-				B637EF63251E56320072D238 /* GPS */,
+				B637EF63251E56320072D238 /* Location */,
 				B637EF71251E56320072D238 /* Data */,
 				B637EF66251E56320072D238 /* Payload */,
 				B637EF65251E56320072D238 /* Sensor.swift */,
@@ -180,12 +180,12 @@
 			path = BLE;
 			sourceTree = "<group>";
 		};
-		B637EF63251E56320072D238 /* GPS */ = {
+		B637EF63251E56320072D238 /* Location */ = {
 			isa = PBXGroup;
 			children = (
-				B637EF64251E56320072D238 /* GPSSensor.swift */,
+				B637EF64251E56320072D238 /* AwakeSensor.swift */,
 			);
-			path = GPS;
+			path = Location;
 			sourceTree = "<group>";
 		};
 		B637EF66251E56320072D238 /* Payload */ = {
@@ -390,7 +390,7 @@
 				B6F745F4255713C2003567B7 /* Interactions.swift in Sources */,
 				B637EF89251E56320072D238 /* BatteryLog.swift in Sources */,
 				B650151425229D060070F774 /* SimplePayloadDataSupplier.swift in Sources */,
-				B637EF7E251E56320072D238 /* GPSSensor.swift in Sources */,
+				B637EF7E251E56320072D238 /* AwakeSensor.swift in Sources */,
 				B637EF7C251E56320072D238 /* BLETransmitter.swift in Sources */,
 				B637EF82251E56320072D238 /* SHA.swift in Sources */,
 				B637EF81251E56320072D238 /* DayCodes.swift in Sources */,

--- a/herald/herald/Sensor/Data/ContactLog.swift
+++ b/herald/herald/Sensor/Data/ContactLog.swift
@@ -50,7 +50,11 @@ class ContactLog: NSObject, SensorDelegate {
         }
     }
     
-    func sensor(_ sensor: SensorType, didVisit: Location) {
-        textFile.write(timestamp() + "," + sensor.rawValue + ",,,,,,5," + csv(didVisit.description))
+    func sensor(_ sensor: SensorType, didVisit: Location?) {
+        var visitString = ""
+        if let dv = didVisit {
+            visitString = dv.description
+        }
+        textFile.write(timestamp() + "," + sensor.rawValue + ",,,,,,5," + csv(visitString))
     }
 }

--- a/herald/herald/Sensor/Location/AwakeSensor.swift
+++ b/herald/herald/Sensor/Location/AwakeSensor.swift
@@ -1,5 +1,5 @@
 //
-//  GPSSensor.swift
+//  AwakeSensor.swift
 //
 //  Copyright 2020 VMware, Inc.
 //  SPDX-License-Identifier: Apache-2.0
@@ -8,17 +8,17 @@
 import Foundation
 import CoreLocation
 
-protocol GPSSensor : Sensor {
+protocol AwakeSensor : Sensor {
 }
 
 /**
- GPS and location sensor based on CoreLocation.
+ Screen awake sensor based on CoreLocation. Does NOT make use of the GPS position
  Requires : Signing & Capabilities : BackgroundModes : LocationUpdates = YES
  Requires : Info.plist : Privacy - Location When In Use Usage Description
  Requires : Info.plist : Privacy - Location Always and When In Use Usage Description
  */
-class ConcreteGPSSensor : NSObject, GPSSensor, CLLocationManagerDelegate {
-    private let logger = ConcreteSensorLogger(subsystem: "Sensor", category: "ConcreteGPSSensor")
+class ConcreteAwakeSensor : NSObject, AwakeSensor, CLLocationManagerDelegate {
+    private let logger = ConcreteSensorLogger(subsystem: "Sensor", category: "ConcreteAwakeSensor")
     private var delegates: [SensorDelegate] = []
     private let locationManager = CLLocationManager()
     private let rangeForBeacon: UUID?
@@ -99,7 +99,7 @@ class ConcreteGPSSensor : NSObject, GPSSensor, CLLocationManagerDelegate {
             locationManager.startUpdatingLocation()
         }
         if status != CLAuthorizationStatus.notDetermined {
-            delegates.forEach({ $0.sensor(.GPS, didUpdateState: state) })
+            delegates.forEach({ $0.sensor(.AWAKE, didUpdateState: state) })
         }
     }
 
@@ -116,15 +116,16 @@ class ConcreteGPSSensor : NSObject, GPSSensor, CLLocationManagerDelegate {
             locationManager.startUpdatingLocation()
         }
         if manager.authorizationStatus != CLAuthorizationStatus.notDetermined {
-            delegates.forEach({ $0.sensor(.GPS, didUpdateState: state) })
+            delegates.forEach({ $0.sensor(.AWAKE, didUpdateState: state) })
         }
     }
     
-//    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-//        logger.debug("locationManager:didUpdateLocations(locations=\(locations.description))")
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        logger.debug("locationManager:didUpdateLocations()")
 //        guard locations.count > 0 else {
 //            return
 //        }
+          // Commented out as we don't use or need the actual location of a device in Herald for the on awake event
 //        locations.forEach() { location in
 //            let location = Location(
 //                value: WGS84PointLocationReference(
@@ -134,5 +135,6 @@ class ConcreteGPSSensor : NSObject, GPSSensor, CLLocationManagerDelegate {
 //                time: (start: location.timestamp, end: location.timestamp))
 //            delegates.forEach { $0.sensor(.GPS, didVisit: location) }
 //        }
-//    }
+        delegates.forEach { $0.sensor(.AWAKE, didVisit: nil) }
+    }
 }

--- a/herald/herald/Sensor/SensorArray.swift
+++ b/herald/herald/Sensor/SensorArray.swift
@@ -29,7 +29,7 @@ public class SensorArray : NSObject, Sensor {
         //   service discovery, to enable characteristic read / write / notify with other
         //   iOS and Android devices.
         if (BLESensorConfiguration.awakeOnLocationEnabled) {
-            sensorArray.append(ConcreteGPSSensor(rangeForBeacon: UUID(uuidString:  BLESensorConfiguration.serviceUUID.uuidString)))
+            sensorArray.append(ConcreteAwakeSensor(rangeForBeacon: UUID(uuidString:  BLESensorConfiguration.serviceUUID.uuidString)))
         }
         // BLE sensor for detecting and tracking proximity
         concreteBle = ConcreteBLESensor(payloadDataSupplier)

--- a/herald/herald/Sensor/SensorDelegate.swift
+++ b/herald/herald/Sensor/SensorDelegate.swift
@@ -25,7 +25,7 @@ public protocol SensorDelegate {
     func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier)
     
     /// Detection of time spent at location, e.g. at specific restaurant between 02/06/2020 19:00 and 02/06/2020 21:00
-    func sensor(_ sensor: SensorType, didVisit: Location)
+    func sensor(_ sensor: SensorType, didVisit: Location?)
     
     /// Measure proximity to target with payload data. Combines didMeasure and didRead into a single convenient delegate method
     func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier, withPayload: PayloadData)
@@ -41,7 +41,7 @@ public extension SensorDelegate {
     func sensor(_ sensor: SensorType, didShare: [PayloadData], fromTarget: TargetIdentifier) {}
     func sensor(_ sensor: SensorType, didReceive: Data, fromTarget: TargetIdentifier) {}
     func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier) {}
-    func sensor(_ sensor: SensorType, didVisit: Location) {}
+    func sensor(_ sensor: SensorType, didVisit: Location?) {}
     func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier, withPayload: PayloadData) {}
     func sensor(_ sensor: SensorType, didUpdateState: SensorState) {}
 }
@@ -52,12 +52,18 @@ public extension SensorDelegate {
 public enum SensorType : String {
     /// Bluetooth Low Energy (BLE)
     case BLE
-    /// GPS location sensor
+    /// Bluetooth Mesh (5.0+)
+    case BLMESH
+    /// Awake location sensor - uses Location API to be alerted to screen on events
+    case AWAKE
+    /// GPS location sensor - not used by default in Herald
     case GPS
     /// Physical beacon, e.g. iBeacon
     case BEACON
     /// Ultrasound audio beacon.
     case ULTRASOUND
+    /// Other - Incase of an extension between minor versions of Herald
+    case OTHER
 }
 
 /// Sensor state


### PR DESCRIPTION
Renamed GPSSensor to AwakeSensor
- Sensor didn't log location or share it any longer
- New title better reflects actual function, even though location permissions still needed
- This sensor is OPTIONAL in Herald, and NOT required for proper function
- Sensor is 'on by default' as iOS 14.2 permission changes meant there is no downside adoption wise of doing this any longer
Signed-off-by: Adam Fowler <adamfowleruk@gmail.com>