### PR TITLE
Movement sensor - Validated

### DIFF
--- a/Herald-for-iOS.xcodeproj/project.pbxproj
+++ b/Herald-for-iOS.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5NRR4P5W72;
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
@@ -407,7 +407,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5NRR4P5W72;
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;

--- a/Herald-for-iOS/Info.plist
+++ b/Herald-for-iOS/Info.plist
@@ -43,6 +43,7 @@
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>
+		<string>accelerometer</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>

--- a/herald/Herald.xcodeproj/project.pbxproj
+++ b/herald/Herald.xcodeproj/project.pbxproj
@@ -42,7 +42,9 @@
 		B650151425229D060070F774 /* SimplePayloadDataSupplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B650151325229D060070F774 /* SimplePayloadDataSupplier.swift */; };
 		B650152025229D480070F774 /* Herald.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B637EF50251E55E60072D238 /* Herald.framework */; platformFilter = ios; };
 		B650152925229D760070F774 /* SimplePayloadDataSupplierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B650152825229D760070F774 /* SimplePayloadDataSupplierTests.swift */; };
+		B6599D0325A4EB0C00AC306D /* InertiaSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6599D0225A4EB0C00AC306D /* InertiaSensor.swift */; };
 		B68DAB8A2580040400F396D7 /* EventTimeIntervalLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68DAB892580040400F396D7 /* EventTimeIntervalLog.swift */; };
+		B6DA10B325A78AF50071C08E /* CalibrationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DA10B225A78AF50071C08E /* CalibrationLog.swift */; };
 		B6F745F2255713C2003567B7 /* SocialDistance.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F745EF255713C2003567B7 /* SocialDistance.swift */; };
 		B6F745F3255713C2003567B7 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F745F0255713C2003567B7 /* Sample.swift */; };
 		B6F745F4255713C2003567B7 /* Interactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F745F1255713C2003567B7 /* Interactions.swift */; };
@@ -104,8 +106,10 @@
 		B650151325229D060070F774 /* SimplePayloadDataSupplier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SimplePayloadDataSupplier.swift; path = herald/Sensor/Payload/Simple/SimplePayloadDataSupplier.swift; sourceTree = SOURCE_ROOT; };
 		B650151B25229D480070F774 /* HeraldTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HeraldTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B650152825229D760070F774 /* SimplePayloadDataSupplierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePayloadDataSupplierTests.swift; sourceTree = "<group>"; };
+		B6599D0225A4EB0C00AC306D /* InertiaSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InertiaSensor.swift; path = herald/Sensor/Motion/InertiaSensor.swift; sourceTree = SOURCE_ROOT; };
 		B68DAB892580040400F396D7 /* EventTimeIntervalLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EventTimeIntervalLog.swift; path = herald/Sensor/Data/EventTimeIntervalLog.swift; sourceTree = SOURCE_ROOT; };
 		B6D8A56E25229F33000E6CC2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B6DA10B225A78AF50071C08E /* CalibrationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CalibrationLog.swift; path = herald/Sensor/Data/CalibrationLog.swift; sourceTree = SOURCE_ROOT; };
 		B6F745EF255713C2003567B7 /* SocialDistance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocialDistance.swift; sourceTree = "<group>"; };
 		B6F745F0255713C2003567B7 /* Sample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sample.swift; sourceTree = "<group>"; };
 		B6F745F1255713C2003567B7 /* Interactions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Interactions.swift; sourceTree = "<group>"; };
@@ -185,6 +189,7 @@
 		B637EF5C251E56320072D238 /* Sensor */ = {
 			isa = PBXGroup;
 			children = (
+				B6599D0125A4EAE600AC306D /* Motion */,
 				B6F745EE255713C2003567B7 /* Analysis */,
 				B637EF5D251E56320072D238 /* BLE */,
 				B637EF63251E56320072D238 /* Location */,
@@ -261,6 +266,7 @@
 				B637EF74251E56320072D238 /* DetectionLog.swift */,
 				B637EF75251E56320072D238 /* SensorLogger.swift */,
 				B637EF76251E56320072D238 /* ContactLog.swift */,
+				B6DA10B225A78AF50071C08E /* CalibrationLog.swift */,
 				B637EF77251E56320072D238 /* StatisticsLog.swift */,
 				B68DAB892580040400F396D7 /* EventTimeIntervalLog.swift */,
 			);
@@ -293,6 +299,14 @@
 				6FBC6F1F25867508001A86CE /* DataExtensionTests.swift */,
 			);
 			path = HeraldTests;
+			sourceTree = "<group>";
+		};
+		B6599D0125A4EAE600AC306D /* Motion */ = {
+			isa = PBXGroup;
+			children = (
+				B6599D0225A4EB0C00AC306D /* InertiaSensor.swift */,
+			);
+			path = Motion;
 			sourceTree = "<group>";
 		};
 		B6F745EE255713C2003567B7 /* Analysis */ = {
@@ -434,9 +448,11 @@
 				B637EF7E251E56320072D238 /* AwakeSensor.swift in Sources */,
 				6F273A48258631190090B3B5 /* SwiftExtensions.swift in Sources */,
 				B637EF7C251E56320072D238 /* BLETransmitter.swift in Sources */,
+				B6599D0325A4EB0C00AC306D /* InertiaSensor.swift in Sources */,
 				B637EF82251E56320072D238 /* SHA.swift in Sources */,
 				B637EF81251E56320072D238 /* DayCodes.swift in Sources */,
 				B637EF8C251E56320072D238 /* ContactLog.swift in Sources */,
+				B6DA10B325A78AF50071C08E /* CalibrationLog.swift in Sources */,
 				B637EF8E251E56320072D238 /* SensorDelegate.swift in Sources */,
 				B637EF86251E56320072D238 /* SensorArray.swift in Sources */,
 				B637EF8D251E56320072D238 /* StatisticsLog.swift in Sources */,

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -105,6 +105,13 @@ public struct BLESensorConfiguration {
     /// - Lower bound : Set this value to Android scan-process period (roughly 2 minutes) to minimise workload, but iOS connection resume will be more reliant on re-discovery (connection resume period = 2 mins or more dependent on external factors).
     /// - iOS-iOS connections may resume beyond the set interval value if the addresses have not changed, due to other mechanisms in Herald.
     public static var peripheralCleanInterval = TimeInterval.minute * 2
+    
+    /// Enable inertia sensor
+    /// - Inertia sensor (accelerometer) measures acceleration in meters per second (m/s) along device X, Y and Z axis
+    /// - Generates SensorDelegate:didVisit callbacks with InertiaLocationReference data
+    /// - Set to false to disable sensor, and true value to enable sensor
+    /// - This is used for automated capture of RSSI at different distances, where the didVisit data is used as markers
+    public static var inertiaSensorEnabled: Bool = false
 }
 
 

--- a/herald/herald/Sensor/Data/CalibrationLog.swift
+++ b/herald/herald/Sensor/Data/CalibrationLog.swift
@@ -1,0 +1,45 @@
+//
+//  CalibrationLog.swift
+//
+//  Copyright 2021 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// CSV contact log for post event analysis and visualisation
+class CalibrationLog: NSObject, SensorDelegate {
+    private let textFile: TextFile
+    private let dateFormatter = DateFormatter()
+    
+    init(filename: String) {
+        textFile = TextFile(filename: filename)
+        if textFile.empty() {
+            textFile.write("time,payload,rssi,x,y,z")
+        }
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    }
+    
+    private func timestamp() -> String {
+        let timestamp = dateFormatter.string(from: Date())
+        return timestamp
+    }
+    
+    private func csv(_ value: String) -> String {
+        return TextFile.csv(value)
+    }
+    
+    // MARK:- SensorDelegate
+    
+    func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier, withPayload: PayloadData) {
+        textFile.write(timestamp() + "," + csv(withPayload.shortName) + "," + csv(didMeasure.value.description) + ",,,")
+    }
+    
+    func sensor(_ sensor: SensorType, didVisit: Location?) {
+        guard let didVisit = didVisit, let reference = didVisit.value as? InertiaLocationReference else {
+            return
+        }
+        let timestamp = dateFormatter.string(from: didVisit.time.start)
+        textFile.write(timestamp + ",,," + reference.x.description + "," + reference.y.description + "," + reference.z.description)
+    }
+}

--- a/herald/herald/Sensor/Motion/InertiaSensor.swift
+++ b/herald/herald/Sensor/Motion/InertiaSensor.swift
@@ -1,0 +1,79 @@
+////
+//  InertiaSensor.swift
+//
+//  Copyright 2021 VMware, Inc.
+//  SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import CoreMotion
+
+/**
+ Inertia sensor for collecting movement data from accelerometer.
+ */
+protocol InertiaSensor : Sensor {
+}
+
+/**
+ Inertia sensor based on CoreMotion
+ Requires : Info.plist : Required Device Capabilities : Accelerometer
+*/
+class ConcreteInertiaSensor : NSObject, InertiaSensor {
+    private let logger = ConcreteSensorLogger(subsystem: "Sensor", category: "Motion.ConcreteInertiaSensor")
+    private let operationQueue = OperationQueue()
+    private let delegateQueue = DispatchQueue(label: "Sensor.Motion.ConcreteInertiaSensor.DelegateQueue")
+    private var delegates: [SensorDelegate] = []
+    private let updateInterval: TimeInterval
+    private let motionManager = CMMotionManager()
+    private var accelerometerHandler: CMAccelerometerHandler!
+    
+    /// Create inertia sensor with given update interval
+    init(updateInterval: TimeInterval = TimeInterval(0.25)) {
+        self.updateInterval = updateInterval
+        super.init()
+        self.accelerometerHandler = { (data, error) in
+            guard error == nil else {
+                return
+            }
+            guard let data = data else {
+                return
+            }
+            let timestamp = Date()
+            // The values reported by the accelerometers are measured in increments
+            // of the gravitational acceleration, with the value 1.0 representing an
+            // acceleration of 9.8 meters per second (per second) in the given direction.
+            // The actual values for each axis is opposite on Android and iOS, i.e.
+            // positive value on iOS = negative value on Android. The callback shall
+            // standardise on Android notation, where y = 9.8 means the phone is being
+            // held vertically with the top edge towards the sky.
+            let x = -data.acceleration.x * 9.8
+            let y = -data.acceleration.y * 9.8
+            let z = -data.acceleration.z * 9.8
+            let inertiaLocationReference = InertiaLocationReference(x: x, y: y, z: z)
+            let location = Location(value: inertiaLocationReference, time: (start: timestamp, end: timestamp))
+            self.delegateQueue.async {
+                self.delegates.forEach { $0.sensor(.ACCELEROMETER, didVisit: location) }
+            }
+        }
+    }
+    
+    func add(delegate: SensorDelegate) {
+        delegates.append(delegate)
+    }
+    
+    func start() {
+        guard motionManager.isAccelerometerAvailable else {
+            logger.fault("start, accelerometer is not available")
+            return
+        }
+        logger.debug("start")
+        motionManager.accelerometerUpdateInterval = updateInterval
+        motionManager.stopAccelerometerUpdates()
+        motionManager.startAccelerometerUpdates(to: operationQueue, withHandler: accelerometerHandler)
+    }
+    
+    func stop() {
+        logger.debug("stop")
+        motionManager.stopAccelerometerUpdates()
+    }
+}

--- a/herald/herald/Sensor/SensorArray.swift
+++ b/herald/herald/Sensor/SensorArray.swift
@@ -34,13 +34,20 @@ public class SensorArray : NSObject, Sensor {
         // BLE sensor for detecting and tracking proximity
         concreteBle = ConcreteBLESensor(payloadDataSupplier)
         sensorArray.append(concreteBle!)
+        
         // Payload data at initiation time for identifying this device in the logs
         payloadData = payloadDataSupplier.payload(PayloadTimestamp(), device: nil)
         super.init()
         logger.debug("device (os=\(UIDevice.current.systemName)\(UIDevice.current.systemVersion),model=\(deviceModel()))")
 
+        // Inertia sensor configured for automated RSSI-distance calibration data capture
+        if BLESensorConfiguration.inertiaSensorEnabled {
+            logger.debug("Inertia sensor enabled");
+            sensorArray.append(ConcreteInertiaSensor());
+            add(delegate: CalibrationLog(filename: "calibration.csv"));
+        }
+
         if let payloadData = payloadData {
-            
             // Loggers
             #if DEBUG
             add(delegate: ContactLog(filename: "contacts.csv"))

--- a/herald/herald/Sensor/SensorDelegate.swift
+++ b/herald/herald/Sensor/SensorDelegate.swift
@@ -62,6 +62,8 @@ public enum SensorType : String {
     case BEACON
     /// Ultrasound audio beacon.
     case ULTRASOUND
+    /// Accelerometer motion sensor
+    case ACCELEROMETER
     /// Other - Incase of an extension between minor versions of Herald
     case OTHER
 }
@@ -174,5 +176,18 @@ public struct PlacenameLocationReference : LocationReference {
     let name: String
     public var description: String { get {
         "PLACE(name=\(name))"
+        }}
+}
+
+/// Acceleration (x,y,z) in meters per second at point in time
+public struct InertiaLocationReference : LocationReference {
+    let x: Double
+    let y: Double
+    let z: Double
+    var magnitude: Double { get {
+        sqrt(x * x + y * y + z * z)
+    }}
+    public var description: String { get {
+        "Inertia(magnitude=\(magnitude),x=\(x),y=\(y),z=\(z))"
         }}
 }


### PR DESCRIPTION
- Optional accelerometer as sensor to mirror Android implementation
- Enables RSSI-Distance reference data capture for iOS-iOS
- Validated on iPhone 4S, 5S, 6S, 6 Plus, X running iOS 9.3.5 to 14.2
- Calibration log cross-platform compatibility tested with Android implementation

Closes #95

Signed-off-by: c19x <support@c19x.org>