### PR TITLE
Make certain sensor properties public

### DIFF
--- a/herald/herald/Sensor/BLE/BLEDatabase.swift
+++ b/herald/herald/Sensor/BLE/BLEDatabase.swift
@@ -201,7 +201,7 @@ public class BLEDevice : Device {
     /// Payload data already shared with this peer
     var payloadSharingData: [PayloadData] = []
     /// Most recent RSSI measurement taken by readRSSI or didDiscover.
-    var rssi: BLE_RSSI? {
+    public var rssi: BLE_RSSI? {
         didSet {
             lastUpdatedAt = Date()
             rssiLastUpdatedAt = lastUpdatedAt
@@ -210,7 +210,7 @@ public class BLEDevice : Device {
     /// RSSI last update timestamp, this is used to track last advertised at without relying on didDiscover
     var rssiLastUpdatedAt: Date = Date.distantPast
     /// Transmit power data where available (only provided by Android devices)
-    var txPower: BLE_TxPower? {
+    public var txPower: BLE_TxPower? {
         didSet {
             lastUpdatedAt = Date()
             delegate.device(self, didUpdate: .txPower)
@@ -308,9 +308,9 @@ enum BLEDeviceOperatingSystem : String {
 }
 
 /// RSSI in dBm.
-typealias BLE_RSSI = Int
+public typealias BLE_RSSI = Int
 
-typealias BLE_TxPower = Int
+public typealias BLE_TxPower = Int
 
 class BLEPseudoDeviceAddress {
     let address: Int64

--- a/herald/herald/Sensor/Device.swift
+++ b/herald/herald/Sensor/Device.swift
@@ -14,7 +14,7 @@ public class Device : NSObject {
     var lastUpdatedAt: Date
     
     /// Ephemeral device identifier, e.g. peripheral identifier UUID
-    var identifier: TargetIdentifier
+    public var identifier: TargetIdentifier
     
     init(_ identifier: TargetIdentifier) {
         self.createdAt = Date()

--- a/herald/herald/Sensor/Extensions/DataExtensions.swift
+++ b/herald/herald/Sensor/Extensions/DataExtensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Accelerate
 
-extension Data {
+public extension Data {
     
     public struct HexEncodingOptions: OptionSet {
         public init(rawValue: Int) {

--- a/herald/herald/Sensor/SensorDelegate.swift
+++ b/herald/herald/Sensor/SensorDelegate.swift
@@ -86,11 +86,11 @@ public typealias TargetIdentifier = String
 /// Raw data for estimating proximity between sensor and target, e.g. RSSI for BLE.
 public struct Proximity {
     /// Unit of measurement, e.g. RSSI
-    let unit: ProximityMeasurementUnit
+    public let unit: ProximityMeasurementUnit
     /// Measured value, e.g. raw RSSI value.
-    let value: Double
+    public let value: Double
     /// Calibration data (optional), e.g. transmit power
-    let calibration: Calibration?
+    public let calibration: Calibration?
     /// Get plain text description of proximity data
     public var description: String { get {
         guard let calibration = calibration else {
@@ -117,9 +117,9 @@ public enum ProximityMeasurementUnit : String {
 /// Calibration data for interpreting proximity value between sensor and target, e.g. Transmit power for BLE.
 public struct Calibration {
     /// Unit of measurement, e.g. transmit power
-    let unit: CalibrationMeasurementUnit
+    public let unit: CalibrationMeasurementUnit
     /// Measured value, e.g. transmit power in BLE advert
-    let value: Double
+    public let value: Double
     /// Get plain text description of calibration data
     public var description: String { get {
         unit.rawValue + ":" + value.description


### PR DESCRIPTION
Publicize Proximity.(unit, value, calibration), Calibration.(unit, value), and Device.identifier for use in Herald-importing codebases.