### PR TITLE
Mobility sensor - Validated

### DIFF
--- a/Herald-for-iOS.xcodeproj/project.pbxproj
+++ b/Herald-for-iOS.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 5NRR4P5W72;
+				DEVELOPMENT_TEAM = "";
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
@@ -407,7 +407,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 5NRR4P5W72;
+				DEVELOPMENT_TEAM = "";
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;

--- a/Herald-for-iOS.xcodeproj/project.pbxproj
+++ b/Herald-for-iOS.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5NRR4P5W72;
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
@@ -407,7 +407,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5NRR4P5W72;
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;

--- a/Herald-for-iOS/PhoneModeViewController.swift
+++ b/Herald-for-iOS/PhoneModeViewController.swift
@@ -40,7 +40,7 @@ class PhoneModeViewController: UIViewController, SensorDelegate, UITableViewData
     
     // MARK:- Social mixing
     
-    private let socialMixingScore = SocialDistance()
+    private let socialMixingScore = SocialDistance(filename: "socialDistance.csv")
     private var socialMixingScoreUnit = TimeInterval(60)
     // Labels to show score over time, each label is a unit
     @IBOutlet weak var labelSocialMixingScore00: UILabel!
@@ -69,6 +69,10 @@ class PhoneModeViewController: UIViewController, SensorDelegate, UITableViewData
     @IBOutlet weak var buttonMessageSend: UIButton!
     @IBOutlet weak var labelMessageReceived: UILabel!
     
+    // MARK:- Mobility
+    
+    private let mobility = Mobility(filename: "mobility.csv")
+    
     // MARK:- Detected payloads
     
     private var targetIdentifiers: [TargetIdentifier:PayloadData] = [:]
@@ -91,6 +95,7 @@ class PhoneModeViewController: UIViewController, SensorDelegate, UITableViewData
         sensor = appDelegate.sensor
         sensor.add(delegate: self)
         sensor.add(delegate: socialMixingScore)
+        sensor.add(delegate: mobility)
         
         
         // Added diary logger

--- a/herald/Herald.xcodeproj/project.pbxproj
+++ b/herald/Herald.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		B68DAB8A2580040400F396D7 /* EventTimeIntervalLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68DAB892580040400F396D7 /* EventTimeIntervalLog.swift */; };
 		B6DA10B325A78AF50071C08E /* CalibrationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DA10B225A78AF50071C08E /* CalibrationLog.swift */; };
 		B6EEC22D25B44A8800D1CDF9 /* Mobility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EEC22C25B44A8800D1CDF9 /* Mobility.swift */; };
+		B6EEC23B25B58E0D00D1CDF9 /* EventLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EEC23A25B58E0D00D1CDF9 /* EventLog.swift */; };
 		B6F745F2255713C2003567B7 /* SocialDistance.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F745EF255713C2003567B7 /* SocialDistance.swift */; };
 		B6F745F3255713C2003567B7 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F745F0255713C2003567B7 /* Sample.swift */; };
 		B6F745F4255713C2003567B7 /* Interactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F745F1255713C2003567B7 /* Interactions.swift */; };
@@ -112,6 +113,7 @@
 		B6D8A56E25229F33000E6CC2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B6DA10B225A78AF50071C08E /* CalibrationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CalibrationLog.swift; path = herald/Sensor/Data/CalibrationLog.swift; sourceTree = SOURCE_ROOT; };
 		B6EEC22C25B44A8800D1CDF9 /* Mobility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Mobility.swift; path = herald/Sensor/Analysis/Mobility.swift; sourceTree = SOURCE_ROOT; };
+		B6EEC23A25B58E0D00D1CDF9 /* EventLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EventLog.swift; path = herald/Sensor/Data/EventLog.swift; sourceTree = SOURCE_ROOT; };
 		B6F745EF255713C2003567B7 /* SocialDistance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocialDistance.swift; sourceTree = "<group>"; };
 		B6F745F0255713C2003567B7 /* Sample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sample.swift; sourceTree = "<group>"; };
 		B6F745F1255713C2003567B7 /* Interactions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Interactions.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 				B6DA10B225A78AF50071C08E /* CalibrationLog.swift */,
 				B637EF77251E56320072D238 /* StatisticsLog.swift */,
 				B68DAB892580040400F396D7 /* EventTimeIntervalLog.swift */,
+				B6EEC23A25B58E0D00D1CDF9 /* EventLog.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -453,6 +456,7 @@
 				6F273A48258631190090B3B5 /* SwiftExtensions.swift in Sources */,
 				B637EF7C251E56320072D238 /* BLETransmitter.swift in Sources */,
 				B6599D0325A4EB0C00AC306D /* InertiaSensor.swift in Sources */,
+				B6EEC23B25B58E0D00D1CDF9 /* EventLog.swift in Sources */,
 				B637EF82251E56320072D238 /* SHA.swift in Sources */,
 				B637EF81251E56320072D238 /* DayCodes.swift in Sources */,
 				B637EF8C251E56320072D238 /* ContactLog.swift in Sources */,

--- a/herald/Herald.xcodeproj/project.pbxproj
+++ b/herald/Herald.xcodeproj/project.pbxproj
@@ -22,7 +22,7 @@
 		B637EF7B251E56320072D238 /* BLEUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF60251E56320072D238 /* BLEUtilities.swift */; };
 		B637EF7C251E56320072D238 /* BLETransmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF61251E56320072D238 /* BLETransmitter.swift */; };
 		B637EF7D251E56320072D238 /* BLEReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF62251E56320072D238 /* BLEReceiver.swift */; };
-		B637EF7E251E56320072D238 /* AwakeSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF64251E56320072D238 /* AwakeSensor.swift */; };
+		B637EF7E251E56320072D238 /* MobilitySensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF64251E56320072D238 /* MobilitySensor.swift */; };
 		B637EF7F251E56320072D238 /* Sensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF65251E56320072D238 /* Sensor.swift */; };
 		B637EF80251E56320072D238 /* SonarPayloadSupplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF68251E56320072D238 /* SonarPayloadSupplier.swift */; };
 		B637EF81251E56320072D238 /* DayCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B637EF6A251E56320072D238 /* DayCodes.swift */; };
@@ -45,6 +45,7 @@
 		B6599D0325A4EB0C00AC306D /* InertiaSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6599D0225A4EB0C00AC306D /* InertiaSensor.swift */; };
 		B68DAB8A2580040400F396D7 /* EventTimeIntervalLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68DAB892580040400F396D7 /* EventTimeIntervalLog.swift */; };
 		B6DA10B325A78AF50071C08E /* CalibrationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DA10B225A78AF50071C08E /* CalibrationLog.swift */; };
+		B6EEC22D25B44A8800D1CDF9 /* Mobility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EEC22C25B44A8800D1CDF9 /* Mobility.swift */; };
 		B6F745F2255713C2003567B7 /* SocialDistance.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F745EF255713C2003567B7 /* SocialDistance.swift */; };
 		B6F745F3255713C2003567B7 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F745F0255713C2003567B7 /* Sample.swift */; };
 		B6F745F4255713C2003567B7 /* Interactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F745F1255713C2003567B7 /* Interactions.swift */; };
@@ -86,7 +87,7 @@
 		B637EF60251E56320072D238 /* BLEUtilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BLEUtilities.swift; sourceTree = "<group>"; };
 		B637EF61251E56320072D238 /* BLETransmitter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BLETransmitter.swift; sourceTree = "<group>"; };
 		B637EF62251E56320072D238 /* BLEReceiver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BLEReceiver.swift; sourceTree = "<group>"; };
-		B637EF64251E56320072D238 /* AwakeSensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AwakeSensor.swift; sourceTree = "<group>"; };
+		B637EF64251E56320072D238 /* MobilitySensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobilitySensor.swift; sourceTree = "<group>"; };
 		B637EF65251E56320072D238 /* Sensor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sensor.swift; sourceTree = "<group>"; };
 		B637EF68251E56320072D238 /* SonarPayloadSupplier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SonarPayloadSupplier.swift; sourceTree = "<group>"; };
 		B637EF6A251E56320072D238 /* DayCodes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DayCodes.swift; sourceTree = "<group>"; };
@@ -110,6 +111,7 @@
 		B68DAB892580040400F396D7 /* EventTimeIntervalLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EventTimeIntervalLog.swift; path = herald/Sensor/Data/EventTimeIntervalLog.swift; sourceTree = SOURCE_ROOT; };
 		B6D8A56E25229F33000E6CC2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B6DA10B225A78AF50071C08E /* CalibrationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CalibrationLog.swift; path = herald/Sensor/Data/CalibrationLog.swift; sourceTree = SOURCE_ROOT; };
+		B6EEC22C25B44A8800D1CDF9 /* Mobility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Mobility.swift; path = herald/Sensor/Analysis/Mobility.swift; sourceTree = SOURCE_ROOT; };
 		B6F745EF255713C2003567B7 /* SocialDistance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocialDistance.swift; sourceTree = "<group>"; };
 		B6F745F0255713C2003567B7 /* Sample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sample.swift; sourceTree = "<group>"; };
 		B6F745F1255713C2003567B7 /* Interactions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Interactions.swift; sourceTree = "<group>"; };
@@ -221,7 +223,7 @@
 		B637EF63251E56320072D238 /* Location */ = {
 			isa = PBXGroup;
 			children = (
-				B637EF64251E56320072D238 /* AwakeSensor.swift */,
+				B637EF64251E56320072D238 /* MobilitySensor.swift */,
 			);
 			path = Location;
 			sourceTree = "<group>";
@@ -316,6 +318,7 @@
 				B6F745F0255713C2003567B7 /* Sample.swift */,
 				B6F745F1255713C2003567B7 /* Interactions.swift */,
 				6F273A4325862B1A0090B3B5 /* VenueDiary.swift */,
+				B6EEC22C25B44A8800D1CDF9 /* Mobility.swift */,
 			);
 			path = Analysis;
 			sourceTree = "<group>";
@@ -434,6 +437,7 @@
 				B637EF85251E56320072D238 /* C19XPayloadSupplier.swift in Sources */,
 				B6F7460025571475003567B7 /* SimplePayloadDataMatcher.swift in Sources */,
 				B637EF7A251E56320072D238 /* BLEDatabase.swift in Sources */,
+				B6EEC22D25B44A8800D1CDF9 /* Mobility.swift in Sources */,
 				B637EF79251E56320072D238 /* BLESensor.swift in Sources */,
 				6F52D4FF257C470B0097DD92 /* BeaconPayloadDataSupplier.swift in Sources */,
 				B6F745F82557145E003567B7 /* PayloadDataMatcher.swift in Sources */,
@@ -445,7 +449,7 @@
 				B6F745F4255713C2003567B7 /* Interactions.swift in Sources */,
 				B637EF89251E56320072D238 /* BatteryLog.swift in Sources */,
 				B650151425229D060070F774 /* SimplePayloadDataSupplier.swift in Sources */,
-				B637EF7E251E56320072D238 /* AwakeSensor.swift in Sources */,
+				B637EF7E251E56320072D238 /* MobilitySensor.swift in Sources */,
 				6F273A48258631190090B3B5 /* SwiftExtensions.swift in Sources */,
 				B637EF7C251E56320072D238 /* BLETransmitter.swift in Sources */,
 				B6599D0325A4EB0C00AC306D /* InertiaSensor.swift in Sources */,

--- a/herald/herald/Sensor/Analysis/Interactions.swift
+++ b/herald/herald/Sensor/Analysis/Interactions.swift
@@ -24,7 +24,7 @@ public class Interactions: NSObject, SensorDelegate {
         super.init()
     }
     
-    public init(filename: String) {
+    public init(filename: String, retention: TimeInterval = TimeInterval.fortnight) {
         textFile = TextFile(filename: filename)
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         queue = DispatchQueue(label: "Sensor.Analysis.EncounterLog(\(filename))")
@@ -43,6 +43,8 @@ public class Interactions: NSObject, SensorDelegate {
                 logger.fault("Failed to read encounter log")
             }
         }
+        // Remove data beyond data retention period
+        remove(before: Date().addingTimeInterval(-retention))
     }
     
     public func append(_ encounter: Encounter) {
@@ -71,7 +73,7 @@ public class Interactions: NSObject, SensorDelegate {
     /// Remove all log records before date (exclusive). Use this function to implement data retention policy.
     public func remove(before: Date) {
         queue.sync {
-            var content = String()
+            var content = "time,proximity,unit,payload\n"
             let subdata = encounters.filter({ $0.timestamp >= before })
             subdata.forEach { encounter in
                 content.append(encounter.csvString)

--- a/herald/herald/Sensor/Analysis/Mobility.swift
+++ b/herald/herald/Sensor/Analysis/Mobility.swift
@@ -1,0 +1,164 @@
+//
+//  Mobility.swift
+//
+//  Copyright 2021 VMware, Inc.
+//  SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+/// Estimate distance travelled without recording actual locations visited to produce mobility indicator for
+/// prioritising work based on potential range of influence
+public class Mobility: NSObject, SensorDelegate {
+    private let logger = ConcreteSensorLogger(subsystem: "Sensor", category: "Analysis.Mobility")
+    private let textFile: TextFile?
+    private let dateFormatter = DateFormatter()
+    private let queue: DispatchQueue
+    private var events: [MobilityEvent] = []
+
+    public override init() {
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        queue = DispatchQueue(label: "Sensor.Analysis.Mobility")
+        textFile = nil
+        super.init()
+    }
+    
+    public init(filename: String, retention: TimeInterval = TimeInterval.fortnight) {
+        textFile = TextFile(filename: filename)
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        queue = DispatchQueue(label: "Sensor.Analysis.Mobility(\(filename))")
+        super.init()
+        if textFile!.empty() {
+            textFile!.write("time,distance")
+        } else if let file = textFile!.url {
+            do {
+                try String(contentsOf: file).split(separator: "\n").forEach { line in
+                    if let event = MobilityEvent(String(line)) {
+                        events.append(event)
+                    }
+                }
+                logger.debug("Loaded historic events (count=\(events.count))")
+            } catch {
+                logger.fault("Failed to read mobility log")
+            }
+        }
+        // Remove data beyond data retention period
+        remove(before: Date().addingTimeInterval(-retention))
+    }
+    
+    public func append(_ event: MobilityEvent) {
+        queue.sync {
+            textFile?.write(event.csvString)
+            events.append(event)
+        }
+    }
+    
+    /// Get records from start date (inclusive) to end date (exclusive)
+    public func subdata(start: Date, end: Date) -> [MobilityEvent] {
+        queue.sync {
+            let subdata = events.filter({ $0.timestamp >= start && $0.timestamp < end })
+            return subdata
+        }
+    }
+
+    /// Get all encounters from start date (inclusive)
+    public func subdata(start: Date) -> [MobilityEvent] {
+        queue.sync {
+            let subdata = events.filter({ $0.timestamp >= start })
+            return subdata
+        }
+    }
+
+    /// Remove all log records before date (exclusive). Use this function to implement data retention policy.
+    public func remove(before: Date) {
+        queue.sync {
+            var content = "time,distance\n"
+            let subdata = events.filter({ $0.timestamp >= before })
+            subdata.forEach { event in
+                content.append(event.csvString)
+                content.append("\n")
+            }
+            textFile?.overwrite(content)
+            events = subdata
+        }
+    }
+    
+    // MARK:- SensorDelegate
+    
+    public func sensor(_ sensor: SensorType, didVisit: Location?) {
+        guard sensor == .MOBILITY else {
+            return
+        }
+        guard let didVisit = didVisit, let locationReference = didVisit.value as? MobilityLocationReference else {
+            return
+        }
+        let event = MobilityEvent(locationReference.distance, timestamp: didVisit.time.end)
+        append(event)
+    }
+    
+    // MARK:- Analysis functions
+    
+    /// Herald achieves > 93% continuity for 30 second windows, thus quantising encounter timestamps into 60 second
+    /// windows will offer a reasonable estimate of the different number of devices within detection range over time. The
+    /// result is a timeseries of different payloads acquired during each 60 second window, along with the proximity data
+    /// for each payload.
+    public func reduceByTime(_ events: [MobilityEvent], duration: TimeInterval = .day) -> [(time: Date, distance: Distance)] {
+        var result: [(Date,Distance)] = []
+        var currentTimeWindow = Date.distantPast
+        var distance: Distance = 0
+        let divisor = Int(duration)
+        events.forEach { event in
+            let timeWindow = Date(timeIntervalSince1970: TimeInterval(Int(event.timestamp.timeIntervalSince1970).dividedReportingOverflow(by: divisor).partialValue * divisor))
+            if timeWindow != currentTimeWindow {
+                if distance > 0 {
+                    result.append((currentTimeWindow, distance))
+                    distance = 0
+                }
+                currentTimeWindow = timeWindow
+            }
+            distance += event.distance
+        }
+        if distance > 0 {
+            result.append((currentTimeWindow, distance))
+        }
+        return result
+    }
+
+}
+
+/// Mobility record describing distance travelled
+public class MobilityEvent {
+    let timestamp: Date
+    let distance: Distance
+    var csvString: String { get {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        let f0 = dateFormatter.string(from: timestamp)
+        let f1 = String(distance)
+        return "\(f0),\(f1)"
+    }}
+    
+    /// Create encounter instance from source data
+    init(_ distance: Distance, timestamp: Date = Date()) {
+        self.timestamp = timestamp
+        self.distance = distance
+    }
+
+    /// Create encounter instance from log entry
+    init?(_ row: String) {
+        let fields = row.split(separator: ",")
+        guard fields.count >= 2 else {
+            return nil
+        }
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        guard let timestamp = dateFormatter.date(from: String(fields[0])) else {
+            return nil
+        }
+        self.timestamp = timestamp
+        guard let distance = Distance(String(fields[1])) else {
+            return nil
+        }
+        self.distance = distance
+    }
+}

--- a/herald/herald/Sensor/Analysis/Mobility.swift
+++ b/herald/herald/Sensor/Analysis/Mobility.swift
@@ -9,83 +9,12 @@ import Foundation
 
 /// Estimate distance travelled without recording actual locations visited to produce mobility indicator for
 /// prioritising work based on potential range of influence
-public class Mobility: NSObject, SensorDelegate {
+public class Mobility: EventLog<MobilityEvent> {
     private let logger = ConcreteSensorLogger(subsystem: "Sensor", category: "Analysis.Mobility")
-    private let textFile: TextFile?
-    private let dateFormatter = DateFormatter()
-    private let queue: DispatchQueue
-    private var events: [MobilityEvent] = []
-
-    public override init() {
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        queue = DispatchQueue(label: "Sensor.Analysis.Mobility")
-        textFile = nil
-        super.init()
-    }
-    
-    public init(filename: String, retention: TimeInterval = TimeInterval.fortnight) {
-        textFile = TextFile(filename: filename)
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        queue = DispatchQueue(label: "Sensor.Analysis.Mobility(\(filename))")
-        super.init()
-        if textFile!.empty() {
-            textFile!.write("time,distance")
-        } else if let file = textFile!.url {
-            do {
-                try String(contentsOf: file).split(separator: "\n").forEach { line in
-                    if let event = MobilityEvent(String(line)) {
-                        events.append(event)
-                    }
-                }
-                logger.debug("Loaded historic events (count=\(events.count))")
-            } catch {
-                logger.fault("Failed to read mobility log")
-            }
-        }
-        // Remove data beyond data retention period
-        remove(before: Date().addingTimeInterval(-retention))
-    }
-    
-    public func append(_ event: MobilityEvent) {
-        queue.sync {
-            textFile?.write(event.csvString)
-            events.append(event)
-        }
-    }
-    
-    /// Get records from start date (inclusive) to end date (exclusive)
-    public func subdata(start: Date, end: Date) -> [MobilityEvent] {
-        queue.sync {
-            let subdata = events.filter({ $0.timestamp >= start && $0.timestamp < end })
-            return subdata
-        }
-    }
-
-    /// Get all encounters from start date (inclusive)
-    public func subdata(start: Date) -> [MobilityEvent] {
-        queue.sync {
-            let subdata = events.filter({ $0.timestamp >= start })
-            return subdata
-        }
-    }
-
-    /// Remove all log records before date (exclusive). Use this function to implement data retention policy.
-    public func remove(before: Date) {
-        queue.sync {
-            var content = "time,distance\n"
-            let subdata = events.filter({ $0.timestamp >= before })
-            subdata.forEach { event in
-                content.append(event.csvString)
-                content.append("\n")
-            }
-            textFile?.overwrite(content)
-            events = subdata
-        }
-    }
     
     // MARK:- SensorDelegate
     
-    public func sensor(_ sensor: SensorType, didVisit: Location?) {
+    public override func sensor(_ sensor: SensorType, didVisit: Location?) {
         guard sensor == .MOBILITY else {
             return
         }
@@ -93,48 +22,28 @@ public class Mobility: NSObject, SensorDelegate {
             return
         }
         let event = MobilityEvent(locationReference.distance, timestamp: didVisit.time.end)
+        logger.debug("didVisit(event=\(event))")
         append(event)
     }
     
     // MARK:- Analysis functions
     
-    /// Herald achieves > 93% continuity for 30 second windows, thus quantising encounter timestamps into 60 second
-    /// windows will offer a reasonable estimate of the different number of devices within detection range over time. The
-    /// result is a timeseries of different payloads acquired during each 60 second window, along with the proximity data
-    /// for each payload.
-    public func reduceByTime(_ events: [MobilityEvent], duration: TimeInterval = .day) -> [(time: Date, distance: Distance)] {
-        var result: [(Date,Distance)] = []
-        var currentTimeWindow = Date.distantPast
-        var distance: Distance = 0
-        let divisor = Int(duration)
-        events.forEach { event in
-            let timeWindow = Date(timeIntervalSince1970: TimeInterval(Int(event.timestamp.timeIntervalSince1970).dividedReportingOverflow(by: divisor).partialValue * divisor))
-            if timeWindow != currentTimeWindow {
-                if distance > 0 {
-                    result.append((currentTimeWindow, distance))
-                    distance = 0
-                }
-                currentTimeWindow = timeWindow
-            }
-            distance += event.distance
-        }
-        if distance > 0 {
-            result.append((currentTimeWindow, distance))
-        }
-        return result
+    public func reduce(into timeWindow: TimeInterval) -> [(time: Date, distance: Distance)] {
+        let timeWindows = super.reduce(into: timeWindow)
+        return timeWindows.map({ ($0.time, $0.events.reduce(into: Distance(0), { total, event in total += event.distance })) })
     }
-
 }
 
 /// Mobility record describing distance travelled
-public class MobilityEvent {
-    let timestamp: Date
-    let distance: Distance
-    var csvString: String { get {
+public class MobilityEvent: Event {
+    public static var csvHeader: String = "time,distance"
+    public let timestamp: Date
+    public let distance: Distance
+    public var csvString: String { get {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         let f0 = dateFormatter.string(from: timestamp)
-        let f1 = String(distance)
+        let f1 = String(round(distance))
         return "\(f0),\(f1)"
     }}
     
@@ -145,8 +54,8 @@ public class MobilityEvent {
     }
 
     /// Create encounter instance from log entry
-    init?(_ row: String) {
-        let fields = row.split(separator: ",")
+    required public init?(_ csvString: String) {
+        let fields = csvString.split(separator: ",")
         guard fields.count >= 2 else {
             return nil
         }

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -83,7 +83,7 @@ public struct BLESensorConfiguration {
     /// - Use this for prioritising positive cases that may have spread the disease over significant distances
     /// - Enabling location permission also has the benefit of enabling  awake on screen for iOS-iOS background detection
     /// - Set to nil to disable sensor, set to distance in metres to enable sensor for mobility sensing at given resolution.
-    public static var mobilitySensorEnabled: Distance? = 3000
+    public static var mobilitySensorEnabled: Distance? = ConcreteMobilitySensor.minimumResolution
     
     /// Payload update at regular intervals, in addition to default HERALD communication process.
     /// - Use this to enable regular payload reads according to app payload lifespan.

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -79,8 +79,11 @@ public struct BLESensorConfiguration {
     /// Log level for BLESensor
     public static var logLevel: SensorLoggerLevel = .debug
     
-    /// Are Location Permissions enabled in the app, and thus awake on screen on enabled
-    public static var awakeOnLocationEnabled: Bool = true
+    /// Mobility sensor for estimating range of travel without recording location
+    /// - Use this for prioritising positive cases that may have spread the disease over significant distances
+    /// - Enabling location permission also has the benefit of enabling  awake on screen for iOS-iOS background detection
+    /// - Set to nil to disable sensor, set to distance in metres to enable sensor for mobility sensing at given resolution.
+    public static var mobilitySensorEnabled: Distance? = 3000
     
     /// Payload update at regular intervals, in addition to default HERALD communication process.
     /// - Use this to enable regular payload reads according to app payload lifespan.

--- a/herald/herald/Sensor/BLE/BLEUtilities.swift
+++ b/herald/herald/Sensor/BLE/BLEUtilities.swift
@@ -86,10 +86,12 @@ extension CBPeripheralState: CustomStringConvertible {
  Extension to make the time intervals more human readable in code.
  */
 extension TimeInterval {
-    static var never: TimeInterval { get { TimeInterval(Int.max) } }
-    static var day: TimeInterval { get { TimeInterval(86400) } }
-    static var hour: TimeInterval { get { TimeInterval(3600) } }
-    static var minute: TimeInterval { get { TimeInterval(60) } }
+    public static var never: TimeInterval { get { TimeInterval(Int.max) } }
+    public static var fortnight: TimeInterval { get { TimeInterval(1209600) }}
+    public static var week: TimeInterval { get { TimeInterval(604800) }}
+    public static var day: TimeInterval { get { TimeInterval(86400) } }
+    public static var hour: TimeInterval { get { TimeInterval(3600) } }
+    public static var minute: TimeInterval { get { TimeInterval(60) } }
 }
 
 /**

--- a/herald/herald/Sensor/Data/EventLog.swift
+++ b/herald/herald/Sensor/Data/EventLog.swift
@@ -1,0 +1,132 @@
+//
+//  EventLog.swift
+//
+//  Copyright 2021 VMware, Inc.
+//  SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+/// Generic event log with optional data retention enforcement functions
+public class EventLog<T:Event>: NSObject, SensorDelegate {
+    private let logger = ConcreteSensorLogger(subsystem: "Sensor", category: "Data.EventLog")
+    private let textFile: TextFile?
+    private let queue: DispatchQueue
+    public var events: [T] = []
+
+    public override init() {
+        queue = DispatchQueue(label: "Sensor.Data.EventLog")
+        textFile = nil
+        super.init()
+    }
+    
+    public init(filename: String) {
+        textFile = TextFile(filename: filename)
+        queue = DispatchQueue(label: "Sensor.Data.EventLog(\(filename))")
+        super.init()
+        if textFile!.empty() {
+            textFile!.write(T.csvHeader)
+        } else if let file = textFile!.url {
+            do {
+                try String(contentsOf: file).split(separator: "\n").forEach { line in
+                    if let event = T(String(line)) {
+                        events.append(event)
+                    }
+                }
+                logger.debug("Loaded historic events (count=\(events.count))")
+            } catch {
+                logger.fault("Failed to read event log")
+            }
+        }
+    }
+    
+    public func append(_ event: T) {
+        logger.debug("append(\(event.csvString))")
+        queue.sync {
+            textFile?.write(event.csvString)
+            events.append(event)
+        }
+    }
+    
+    /// Get records from start date (inclusive) to end date (exclusive)
+    public func subdata(start: Date, end: Date) -> [T] {
+        queue.sync {
+            let subdata = events.filter({ $0.timestamp >= start && $0.timestamp < end })
+            return subdata
+        }
+    }
+
+    /// Get all encounters from start date (inclusive)
+    public func subdata(start: Date) -> [T] {
+        queue.sync {
+            let subdata = events.filter({ $0.timestamp >= start })
+            return subdata
+        }
+    }
+
+    /// Remove all log records before date (exclusive). Use this function to implement data retention policy.
+    public func remove(before: Date) {
+        queue.sync {
+            var content = "\(T.csvHeader)\n"
+            let subdata = events.filter({ $0.timestamp >= before })
+            subdata.forEach { event in
+                content.append(event.csvString)
+                content.append("\n")
+            }
+            textFile?.overwrite(content)
+            events = subdata
+        }
+    }
+    
+    /// Remove all log records before retention period.
+    public func removeBefore(retention: TimeInterval) {
+        remove(before: Date().addingTimeInterval(-retention))
+    }
+        
+    // MARK:- Analysis functions
+    
+    /// Get events in time windows
+    public func reduce(into timeWindow: TimeInterval) -> [(time: Date, events: [T])] {
+        var result: [(Date,[T])] = []
+        var currentTimeWindow = Date.distantPast
+        var eventsInTimeWindow: [T] = []
+        let divisor = Int(timeWindow)
+        events.forEach { event in
+            let timeWindow = Date(timeIntervalSince1970: TimeInterval(Int(event.timestamp.timeIntervalSince1970).dividedReportingOverflow(by: divisor).partialValue * divisor))
+            if timeWindow != currentTimeWindow {
+                if !eventsInTimeWindow.isEmpty {
+                    result.append((currentTimeWindow, eventsInTimeWindow))
+                    eventsInTimeWindow = []
+                }
+                currentTimeWindow = timeWindow
+            }
+            eventsInTimeWindow.append(event)
+        }
+        if !eventsInTimeWindow.isEmpty {
+            result.append((currentTimeWindow, eventsInTimeWindow))
+        }
+        return result
+    }
+    
+    // MARK:- SensorDelegate
+    
+    public func sensor(_ sensor: SensorType, didDetect: TargetIdentifier) {}
+    public func sensor(_ sensor: SensorType, didRead: PayloadData, fromTarget: TargetIdentifier) {}
+    public func sensor(_ sensor: SensorType, didShare: [PayloadData], fromTarget: TargetIdentifier) {}
+    public func sensor(_ sensor: SensorType, didReceive: Data, fromTarget: TargetIdentifier) {}
+    public func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier) {}
+    public func sensor(_ sensor: SensorType, didVisit: Location?) {}
+    public func sensor(_ sensor: SensorType, didMeasure: Proximity, fromTarget: TargetIdentifier, withPayload: PayloadData) {}
+    public func sensor(_ sensor: SensorType, didUpdateState: SensorState) {}
+}
+
+/// Event for logging
+public protocol Event {
+    var timestamp: Date { get }
+    /// Get CSV header for event data including timestamp
+    static var csvHeader: String { get }
+    /// Get CSV representation of event data including timestamp
+    var csvString: String { get }
+    /// Parse CSV representation of event data to recreate event
+    init?(_ csvString: String)
+}

--- a/herald/herald/Sensor/SensorArray.swift
+++ b/herald/herald/Sensor/SensorArray.swift
@@ -19,17 +19,12 @@ public class SensorArray : NSObject, Sensor {
     
     public init(_ payloadDataSupplier: PayloadDataSupplier) {
         logger.debug("init")
-        // Location sensor is necessary for enabling background BLE advert detection
-        // - This is optional in iOS 9.3 to 13, because an Android device can act as a relay,
+        // Mobility sensor enables background BLE advert detection
+        // - This is optional because an Android device can act as a relay,
         //   but enabling location sensor will enable direct iOS-iOS detection in background.
-        // - This is mandatory in iOS 14, because service discovery will fail for Android and
-        //   iOS devices unless location sensor has been enabled and the user grants access
-        //   to location. Please note, the actual location is not used nor recorded by HERALD.
-        //   This is only necessary to enable iOS-iOS background BLE advert discovery, and
-        //   service discovery, to enable characteristic read / write / notify with other
-        //   iOS and Android devices.
-        if (BLESensorConfiguration.awakeOnLocationEnabled) {
-            sensorArray.append(ConcreteAwakeSensor(rangeForBeacon: UUID(uuidString:  BLESensorConfiguration.serviceUUID.uuidString)))
+        // - Please note, the actual location is not used or recorded by HERALD.
+        if let mobilitySensorResolution = BLESensorConfiguration.mobilitySensorEnabled {
+            sensorArray.append(ConcreteMobilitySensor(resolution: mobilitySensorResolution, rangeForBeacon: UUID(uuidString:  BLESensorConfiguration.serviceUUID.uuidString)))
         }
         // BLE sensor for detecting and tracking proximity
         concreteBle = ConcreteBLESensor(payloadDataSupplier)

--- a/herald/herald/Sensor/SensorDelegate.swift
+++ b/herald/herald/Sensor/SensorDelegate.swift
@@ -54,8 +54,8 @@ public enum SensorType : String {
     case BLE
     /// Bluetooth Mesh (5.0+)
     case BLMESH
-    /// Awake location sensor - uses Location API to be alerted to screen on events
-    case AWAKE
+    /// Mobility sensor - uses Location API measure range travelled
+    case MOBILITY
     /// GPS location sensor - not used by default in Herald
     case GPS
     /// Physical beacon, e.g. iBeacon
@@ -176,6 +176,17 @@ public struct PlacenameLocationReference : LocationReference {
     let name: String
     public var description: String { get {
         "PLACE(name=\(name))"
+        }}
+}
+
+/// Distance in metres
+public typealias Distance = Double
+
+/// Distance travelled in any direction in metres, as indicator of range of movement.
+public struct MobilityLocationReference : LocationReference {
+    let distance: Distance
+    public var description: String { get {
+        "Mobility(distance=\(distance))"
         }}
 }
 


### PR DESCRIPTION
- Tested on iPhone X (iOS 14.2) and 6S (iOS 12.1.4)
- Replaces AwakeSensor
- Enables anonymous mobility report as indicator of movement range
- Supports work prioritisation based on potential range of influence

Signed-off-by: c19x <support@c19x.org>