### PR TITLE
Data append cross-platform test support - Validated

### DIFF
--- a/herald/HeraldTests/DataExtensionTests.swift
+++ b/herald/HeraldTests/DataExtensionTests.swift
@@ -9,7 +9,6 @@ import XCTest
 @testable import Herald
 
 class DataExtensionTests: XCTestCase {
-    /// MARK:- Basic class functionality tests
     
     func testInt8() throws {
         // Zero, Min, Max
@@ -21,12 +20,19 @@ class DataExtensionTests: XCTestCase {
         XCTAssertEqual(Int8(Int8.min), dataRange.int8(1))
         XCTAssertEqual(Int8(Int8.max), dataRange.int8(2))
         // Values in range
+        var csv = "value,data\n"
         for i in Int8.min...Int8.max {
             let value = Int8(i)
             var data = Data()
             data.append(value)
             XCTAssertEqual(value, data.int8(0))
+            csv.append("\(i),\(data.base64EncodedString())\n")
         }
+        // Generate CSV for comparison with Android
+        let attachment = XCTAttachment(string: csv)
+        attachment.lifetime = .keepAlways
+        attachment.name = "int8.csv"
+        add(attachment)
     }
 
     func testUInt8() throws {
@@ -39,12 +45,18 @@ class DataExtensionTests: XCTestCase {
         XCTAssertEqual(UInt8(UInt8.min), dataRange.uint8(1))
         XCTAssertEqual(UInt8(UInt8.max), dataRange.uint8(2))
         // Values in range
+        var csv = "value,data\n"
         for i in UInt8.min...UInt8.max {
             let value = UInt8(i)
             var data = Data()
             data.append(value)
             XCTAssertEqual(value, data.uint8(0))
+            csv.append("\(i),\(data.base64EncodedString())\n")
         }
+        let attachment = XCTAttachment(string: csv)
+        attachment.lifetime = .keepAlways
+        attachment.name = "uint8.csv"
+        add(attachment)
     }
 
     func testInt16() throws {
@@ -57,12 +69,18 @@ class DataExtensionTests: XCTestCase {
         XCTAssertEqual(Int16(Int16.min), dataRange.int16(2))
         XCTAssertEqual(Int16(Int16.max), dataRange.int16(4))
         // Values in range
+        var csv = "value,data\n"
         for i in Int16.min...Int16.max {
             let value = Int16(i)
             var data = Data()
             data.append(value)
             XCTAssertEqual(value, data.int16(0))
+            csv.append("\(i),\(data.base64EncodedString())\n")
         }
+        let attachment = XCTAttachment(string: csv)
+        attachment.lifetime = .keepAlways
+        attachment.name = "int16.csv"
+        add(attachment)
     }
 
     func testUInt16() throws {
@@ -75,12 +93,18 @@ class DataExtensionTests: XCTestCase {
         XCTAssertEqual(UInt16(UInt16.min), dataRange.uint16(2))
         XCTAssertEqual(UInt16(UInt16.max), dataRange.uint16(4))
         // Values in range
+        var csv = "value,data\n"
         for i in UInt16.min...UInt16.max {
             let value = UInt16(i)
             var data = Data()
             data.append(value)
             XCTAssertEqual(value, data.uint16(0))
+            csv.append("\(i),\(data.base64EncodedString())\n")
         }
+        let attachment = XCTAttachment(string: csv)
+        attachment.lifetime = .keepAlways
+        attachment.name = "uint16.csv"
+        add(attachment)
     }
 
     func testInt32() throws {
@@ -93,15 +117,23 @@ class DataExtensionTests: XCTestCase {
         XCTAssertEqual(Int32(Int32.min), dataRange.int32(4))
         XCTAssertEqual(Int32(Int32.max), dataRange.int32(8))
         // Values in range
+        var csv = "value,data\n"
         var i = 1
         while i <= (Int32.max / 7) {
-            var data = Data()
-            data.append(Int32(i))
-            data.append(Int32(-i))
-            XCTAssertEqual(Int32(i), data.int32(0))
-            XCTAssertEqual(Int32(-i), data.int32(4))
+            var dataPositive = Data()
+            dataPositive.append(Int32(i))
+            XCTAssertEqual(Int32(i), dataPositive.int32(0))
+            csv.append("\(i),\(dataPositive.base64EncodedString())\n")
+            var dataNegative = Data()
+            dataNegative.append(Int32(-i))
+            XCTAssertEqual(Int32(-i), dataNegative.int32(0))
+            csv.append("\(-i),\(dataNegative.base64EncodedString())\n")
             i *= 7
         }
+        let attachment = XCTAttachment(string: csv)
+        attachment.lifetime = .keepAlways
+        attachment.name = "int32.csv"
+        add(attachment)
     }
 
     func testUInt32() throws {
@@ -114,13 +146,19 @@ class DataExtensionTests: XCTestCase {
         XCTAssertEqual(UInt32(UInt32.min), dataRange.uint32(4))
         XCTAssertEqual(UInt32(UInt32.max), dataRange.uint32(8))
         // Values in range
+        var csv = "value,data\n"
         var i = 1
         while i <= (UInt32.max / 7) {
             var data = Data()
             data.append(UInt32(i))
             XCTAssertEqual(UInt32(i), data.uint32(0))
+            csv.append("\(i),\(data.base64EncodedString())\n")
             i *= 7
         }
+        let attachment = XCTAttachment(string: csv)
+        attachment.lifetime = .keepAlways
+        attachment.name = "uint32.csv"
+        add(attachment)
     }
 
     func testInt64() throws {
@@ -133,15 +171,23 @@ class DataExtensionTests: XCTestCase {
         XCTAssertEqual(Int64(Int64.min), dataRange.int64(8))
         XCTAssertEqual(Int64(Int64.max), dataRange.int64(16))
         // Values in range
+        var csv = "value,data\n"
         var i = 1
         while i <= (Int64.max / 7) {
-            var data = Data()
-            data.append(Int64(i))
-            data.append(Int64(-i))
-            XCTAssertEqual(Int64(i), data.int64(0))
-            XCTAssertEqual(Int64(-i), data.int64(8))
+            var dataPositive = Data()
+            dataPositive.append(Int64(i))
+            XCTAssertEqual(Int64(i), dataPositive.int64(0))
+            csv.append("\(i),\(dataPositive.base64EncodedString())\n")
+            var dataNegative = Data()
+            dataNegative.append(Int64(-i))
+            XCTAssertEqual(Int64(-i), dataNegative.int64(0))
+            csv.append("\(-i),\(dataNegative.base64EncodedString())\n")
             i *= 7
         }
+        let attachment = XCTAttachment(string: csv)
+        attachment.lifetime = .keepAlways
+        attachment.name = "int64.csv"
+        add(attachment)
     }
 
     func testUInt64() throws {
@@ -154,13 +200,19 @@ class DataExtensionTests: XCTestCase {
         XCTAssertEqual(UInt64(UInt64.min), dataRange.uint64(8))
         XCTAssertEqual(UInt64(UInt64.max), dataRange.uint64(16))
         // Values in range
+        var csv = "value,data\n"
         var i = 1
         while i <= (UInt64.max / 7) {
             var data = Data()
             data.append(UInt64(i))
             XCTAssertEqual(UInt64(i), data.uint64(0))
+            csv.append("\(i),\(data.base64EncodedString())\n")
             i *= 7
         }
+        let attachment = XCTAttachment(string: csv)
+        attachment.lifetime = .keepAlways
+        attachment.name = "uint64.csv"
+        add(attachment)
     }
     
     func testString() throws {
@@ -171,23 +223,37 @@ class DataExtensionTests: XCTestCase {
         XCTAssertEqual(1, dataRange.string(0)?.start)
         XCTAssertEqual(1, dataRange.string(0)?.end)
         
-        // Values
-        var data = Data()
-        _ = data.append("a", .UINT8)
-        _ = data.append("bb", .UINT16)
-        _ = data.append("ccc", .UINT32)
-        _ = data.append("dddd", .UINT64)
-        XCTAssertEqual("a", data.string(0, .UINT8)?.value)
-        XCTAssertEqual(1, data.string(0, .UINT8)?.start)
-        XCTAssertEqual(2, data.string(0, .UINT8)?.end)
-        XCTAssertEqual("bb", data.string(2, .UINT16)?.value)
-        XCTAssertEqual(4, data.string(2, .UINT16)?.start)
-        XCTAssertEqual(6, data.string(2, .UINT16)?.end)
-        XCTAssertEqual("ccc", data.string(6, .UINT32)?.value)
-        XCTAssertEqual(10, data.string(6, .UINT32)?.start)
-        XCTAssertEqual(13, data.string(6, .UINT32)?.end)
-        XCTAssertEqual("dddd", data.string(13, .UINT64)?.value)
-        XCTAssertEqual(21, data.string(13, .UINT64)?.start)
-        XCTAssertEqual(25, data.string(13, .UINT64)?.end)
+        // Encoding options
+        var dataEncoding = Data()
+        _ = dataEncoding.append("a", .UINT8)
+        _ = dataEncoding.append("bb", .UINT16)
+        _ = dataEncoding.append("ccc", .UINT32)
+        _ = dataEncoding.append("dddd", .UINT64)
+        XCTAssertEqual("a", dataEncoding.string(0, .UINT8)?.value)
+        XCTAssertEqual(1, dataEncoding.string(0, .UINT8)?.start)
+        XCTAssertEqual(2, dataEncoding.string(0, .UINT8)?.end)
+        XCTAssertEqual("bb", dataEncoding.string(2, .UINT16)?.value)
+        XCTAssertEqual(4, dataEncoding.string(2, .UINT16)?.start)
+        XCTAssertEqual(6, dataEncoding.string(2, .UINT16)?.end)
+        XCTAssertEqual("ccc", dataEncoding.string(6, .UINT32)?.value)
+        XCTAssertEqual(10, dataEncoding.string(6, .UINT32)?.start)
+        XCTAssertEqual(13, dataEncoding.string(6, .UINT32)?.end)
+        XCTAssertEqual("dddd", dataEncoding.string(13, .UINT64)?.value)
+        XCTAssertEqual(21, dataEncoding.string(13, .UINT64)?.start)
+        XCTAssertEqual(25, dataEncoding.string(13, .UINT64)?.end)
+        
+        // Values in range
+        var csv = "value,data\n"
+        for s in ["","a","bb","ccc","dddd","eeeee"] {
+            var data = Data()
+            _ = data.append(s)
+            XCTAssertEqual(s, data.string(0)?.value)
+            csv.append("\(s),\(data.base64EncodedString())\n")
+        }
+        let attachment = XCTAttachment(string: csv)
+        attachment.lifetime = .keepAlways
+        attachment.name = "string.csv"
+        add(attachment)
+
     }
 }

--- a/herald/HeraldTests/SimplePayloadDataSupplierTests.swift
+++ b/herald/HeraldTests/SimplePayloadDataSupplierTests.swift
@@ -184,32 +184,6 @@ class SimplePayloadDataSupplierTests: XCTestCase {
         XCTAssertEqual(pds1.payload(K.date("2026-03-18T00:00:00+0000")!, device: nil), pds1.payload(K.date("2026-03-18T00:05:59+0000")!, device: nil))
         XCTAssertEqual(pds1.payload(K.date("2026-03-18T00:00:00+0000")!, device: nil), pds1.payload(K.date("2026-03-18T00:06:00+0000")!, device: nil))
     }
-
-    func testCrossPlatformUInt8() throws {
-        print("value,uint8")
-        for i in 0...255 {
-            let value = UInt8(i)
-            var bigEndian = value.bigEndian
-            let data = Data(bytes: &bigEndian, count: MemoryLayout.size(ofValue: bigEndian))
-            print("\(value),\(data.base64EncodedString())")
-        }
-    }
-
-    func testCrossPlatformUInt16() throws {
-        print("value,uint16")
-        for i in 0...127 {
-            let value = UInt16(i)
-            var bigEndian = value.bigEndian
-            let data = Data(bytes: &bigEndian, count: MemoryLayout.size(ofValue: bigEndian))
-            print("\(value),\(data.base64EncodedString())")
-        }
-        for i in (65536-128)...65535 {
-            let value = UInt16(i)
-            var bigEndian = value.bigEndian
-            let data = Data(bytes: &bigEndian, count: MemoryLayout.size(ofValue: bigEndian))
-            print("\(value),\(data.base64EncodedString())")
-        }
-    }
     
 //    func testCrossPlatformBinary16() throws {
 //        print("value,float16")
@@ -221,7 +195,7 @@ class SimplePayloadDataSupplierTests: XCTestCase {
 //    }
 
     func testContactIdentifierCrossPlatform() throws {
-        print("day,period,matchingKey,contactKey,contactIdentifier");
+        var csv = "day,period,matchingKey,contactKey,contactIdentifier\n"
         // Generate secret and matching keys
         let ks1 = SecretKey(repeating: 0, count: 2048)
         let km1 = K.matchingKeys(ks1)
@@ -230,15 +204,24 @@ class SimplePayloadDataSupplierTests: XCTestCase {
             let kc1 = K.contactKeys(km1[day])
             for period in 0...240 {
                 let Ic1 = K.contactIdentifier(kc1[period])
-                print("\(day),\(period),\(km1[day].base64EncodedString()),\(kc1[period].base64EncodedString()),\(Ic1.base64EncodedString())")
+                csv.append("\(day),\(period),\(km1[day].base64EncodedString()),\(kc1[period].base64EncodedString()),\(Ic1.base64EncodedString())\n")
             }
         }
+        let attachment = XCTAttachment(string: csv)
+        attachment.lifetime = .keepAlways
+        attachment.name = "contactIdentifier.csv"
+        add(attachment)
     }
     
     func testPayloadData() throws {
+        var csv = "value,data\n"
         for i in 0...600 {
             let payloadData = PayloadData(repeating: 0, count: i)
-            print("\(i) -> \(payloadData.shortName)")
+            csv.append("\(i),\(payloadData.shortName)\n")
         }
+        let attachment = XCTAttachment(string: csv)
+        attachment.lifetime = .keepAlways
+        attachment.name = "payloadDataShortName.csv"
+        add(attachment)
     }
 }


### PR DESCRIPTION
- Data tests for Int/UInt 8,16,32,64 and String generate comparable plain text files (CSV) as attachment for each test
- Android implementation of Data generate the same set of files
- The files are compared to ensure cross-platform compatiblity
- Validated Int/UInt 8,16,32,64 and String for cross-platform compatibility

Signed-off-by: c19x <support@c19x.org>