### PR TITLE
Legacy payload capture - Validated

### DIFF
--- a/Herald-for-iOS.xcodeproj/project.pbxproj
+++ b/Herald-for-iOS.xcodeproj/project.pbxproj
@@ -387,7 +387,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 5NRR4P5W72;
+				DEVELOPMENT_TEAM = "";
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
@@ -407,7 +407,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 5NRR4P5W72;
+				DEVELOPMENT_TEAM = "";
 				EXCLUDED_SOURCE_FILE_NAMES = "/Resources/*";
 				INFOPLIST_FILE = "$(SRCROOT)/Herald-for-iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;

--- a/Herald-for-iOS/TargetDetailsViewController.swift
+++ b/Herald-for-iOS/TargetDetailsViewController.swift
@@ -45,7 +45,7 @@ class TargetDetailsViewController: UIViewController, UITableViewDataSource, UITa
             lblId.text = target.description.prefix(17) + "..."
         }
         
-        lblPayload.text = payload.hexEncodedString(options: .upperCase)
+        lblPayload.text = payload.hexEncodedString
         // TODO trim the above text if very long
         
         // vary display based on data in Payload

--- a/herald/Herald.xcodeproj/project.pbxproj
+++ b/herald/Herald.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		B650152925229D760070F774 /* SimplePayloadDataSupplierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B650152825229D760070F774 /* SimplePayloadDataSupplierTests.swift */; };
 		B6599D0325A4EB0C00AC306D /* InertiaSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6599D0225A4EB0C00AC306D /* InertiaSensor.swift */; };
 		B68DAB8A2580040400F396D7 /* EventTimeIntervalLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68DAB892580040400F396D7 /* EventTimeIntervalLog.swift */; };
+		B69F189925B84B32001CC891 /* BLEAdvertParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69F189825B84B32001CC891 /* BLEAdvertParser.swift */; };
+		B69F189D25B8A6AB001CC891 /* BLEAdvertParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69F189C25B8A6AB001CC891 /* BLEAdvertParserTests.swift */; };
 		B6DA10B325A78AF50071C08E /* CalibrationLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DA10B225A78AF50071C08E /* CalibrationLog.swift */; };
 		B6EEC22D25B44A8800D1CDF9 /* Mobility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EEC22C25B44A8800D1CDF9 /* Mobility.swift */; };
 		B6EEC23B25B58E0D00D1CDF9 /* EventLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EEC23A25B58E0D00D1CDF9 /* EventLog.swift */; };
@@ -101,6 +103,8 @@
 		B650152825229D760070F774 /* SimplePayloadDataSupplierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePayloadDataSupplierTests.swift; sourceTree = "<group>"; };
 		B6599D0225A4EB0C00AC306D /* InertiaSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InertiaSensor.swift; path = herald/Sensor/Motion/InertiaSensor.swift; sourceTree = SOURCE_ROOT; };
 		B68DAB892580040400F396D7 /* EventTimeIntervalLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = EventTimeIntervalLog.swift; path = herald/Sensor/Data/EventTimeIntervalLog.swift; sourceTree = SOURCE_ROOT; };
+		B69F189825B84B32001CC891 /* BLEAdvertParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BLEAdvertParser.swift; path = herald/Sensor/BLE/BLEAdvertParser.swift; sourceTree = SOURCE_ROOT; };
+		B69F189C25B8A6AB001CC891 /* BLEAdvertParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BLEAdvertParserTests.swift; sourceTree = "<group>"; };
 		B6D8A56E25229F33000E6CC2 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B6DA10B225A78AF50071C08E /* CalibrationLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CalibrationLog.swift; path = herald/Sensor/Data/CalibrationLog.swift; sourceTree = SOURCE_ROOT; };
 		B6EEC22C25B44A8800D1CDF9 /* Mobility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Mobility.swift; path = herald/Sensor/Analysis/Mobility.swift; sourceTree = SOURCE_ROOT; };
@@ -210,6 +214,7 @@
 				B637EF60251E56320072D238 /* BLEUtilities.swift */,
 				B637EF61251E56320072D238 /* BLETransmitter.swift */,
 				B637EF62251E56320072D238 /* BLEReceiver.swift */,
+				B69F189825B84B32001CC891 /* BLEAdvertParser.swift */,
 			);
 			path = BLE;
 			sourceTree = "<group>";
@@ -281,6 +286,7 @@
 				6F273A4B258631AF0090B3B5 /* VenueDiaryEventTests.swift */,
 				6F273A4F258641CA0090B3B5 /* VenueDiaryTests.swift */,
 				6FBC6F1F25867508001A86CE /* DataExtensionTests.swift */,
+				B69F189C25B8A6AB001CC891 /* BLEAdvertParserTests.swift */,
 			);
 			path = HeraldTests;
 			sourceTree = "<group>";
@@ -423,6 +429,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B69F189925B84B32001CC891 /* BLEAdvertParser.swift in Sources */,
 				B637EF7D251E56320072D238 /* BLEReceiver.swift in Sources */,
 				B637EF7B251E56320072D238 /* BLEUtilities.swift in Sources */,
 				B6F7460025571475003567B7 /* SimplePayloadDataMatcher.swift in Sources */,
@@ -474,6 +481,7 @@
 				6F273A4C258631AF0090B3B5 /* VenueDiaryEventTests.swift in Sources */,
 				B6F7460C255714C2003567B7 /* InteractionsTests.swift in Sources */,
 				B6F7460B255714C2003567B7 /* BloomFilterTests.swift in Sources */,
+				B69F189D25B8A6AB001CC891 /* BLEAdvertParserTests.swift in Sources */,
 				6F273A50258641CA0090B3B5 /* VenueDiaryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/herald/HeraldTests/BLEAdvertParserTests.swift
+++ b/herald/HeraldTests/BLEAdvertParserTests.swift
@@ -1,0 +1,111 @@
+//
+//  BLEAdvertParserTests.swift
+//
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+@testable import Herald
+
+class BLEAdvertParserTests: XCTestCase {
+
+    // MARK: Low level individual parsing functions
+
+    func testDataSubsetBigEndian() throws {
+        let data = Data([0,1,5,6,7,8,12,13,14])
+        XCTAssertEqual(5, data[2])
+        XCTAssertEqual(6, data[3])
+        XCTAssertEqual(7, data[4])
+        XCTAssertEqual(8, data[5])
+        let result = BLEAdvertParser.subDataBigEndian(data,2,4)
+        XCTAssertEqual(4, result.count)
+        XCTAssertEqual(5, result[0])
+        XCTAssertEqual(6, result[1])
+        XCTAssertEqual(7, result[2])
+        XCTAssertEqual(8, result[3])
+    }
+
+    func testDataSubsetLittleEndian() throws {
+        let data = Data([0,1,5,6,7,8,12,13,14])
+        let result = BLEAdvertParser.subDataLittleEndian(data,2,4)
+        XCTAssertEqual(4, result.count)
+        XCTAssertEqual(8, result[0])
+        XCTAssertEqual(7, result[1])
+        XCTAssertEqual(6, result[2])
+        XCTAssertEqual(5, result[3])
+    }
+
+    func testDataSubsetBigEndianOverflow() throws {
+        let data = Data([0,1,5,6,7])
+        let result = BLEAdvertParser.subDataBigEndian(data,2,4)
+        XCTAssertEqual(0, result.count)
+    }
+
+    func testDataSubsetLittleEndianOverflow() throws {
+        let data = Data([0,1,5,6,7])
+        let result = BLEAdvertParser.subDataLittleEndian(data,2,4)
+        XCTAssertEqual(0, result.count)
+    }
+
+    func testDataSubsetBigEndianLowIndex() throws {
+        let data = Data([0,1,5,6,7])
+        let result = BLEAdvertParser.subDataBigEndian(data,-1,4)
+        XCTAssertEqual(0, result.count)
+    }
+
+    func testDataSubsetLittleEndianLowIndex() throws {
+        let data = Data([0,1,5,6,7])
+        let result = BLEAdvertParser.subDataLittleEndian(data,-1,4)
+        XCTAssertEqual(0, result.count)
+    }
+
+    func testDataSubsetBigEndianHighIndex() throws {
+        let data = Data([0,1,5,6,7])
+        let result = BLEAdvertParser.subDataBigEndian(data,5,4)
+        XCTAssertEqual(0, result.count)
+    }
+
+    func testDataSubsetLittleEndianHighIndex() throws {
+        let data = Data([0,1,5,6,7])
+        let result = BLEAdvertParser.subDataLittleEndian(data,5,4)
+        XCTAssertEqual(0, result.count)
+    }
+
+    func testDataSubsetBigEndianLargeLength() throws {
+        let data = Data([0,1,5,6,7])
+        let result = BLEAdvertParser.subDataBigEndian(data,2,4)
+        XCTAssertEqual(0, result.count)
+    }
+
+    func testDataSubsetLittleEndianLargeLength() throws {
+        let data = Data([0,1,5,6,7])
+        let result = BLEAdvertParser.subDataLittleEndian(data,2,4)
+        XCTAssertEqual(0, result.count)
+    }
+
+    func testDataSubsetBigEndianEmptyData() throws {
+        let data = Data()
+        let result = BLEAdvertParser.subDataBigEndian(data,0,1)
+        XCTAssertEqual(0, result.count)
+    }
+
+    func testDataSubsetLittleEndianEmptyData() throws {
+        let data = Data()
+        let result = BLEAdvertParser.subDataLittleEndian(data,0,1)
+        XCTAssertEqual(0, result.count)
+    }
+    
+    func testExtractMessages_iPhoneX_F() throws {
+        let raw = Data(hexEncodedString:
+            "02011A020A0C0BFF4C001006071EA3DD89E014FF4C00010000000000000000" +
+            "00002000000000000000000000000000000000000000000000000000000000")!
+        let segments = BLEAdvertParser.extractSegments(raw, 0)
+        print(segments.map({ $0.description }))
+        let manufacturerDataSegments = BLEAdvertParser.extractManufacturerData(segments: segments)
+        print(manufacturerDataSegments.map({ $0.description }))
+        XCTAssertEqual("1006071EA3DD89E0", manufacturerDataSegments[0].data.hexEncodedString)
+        XCTAssertEqual("0100000000000000000000200000000000", manufacturerDataSegments[1].data.hexEncodedString)
+    }
+
+}

--- a/herald/HeraldTests/BeaconPayloadDataSupplierTests.swift
+++ b/herald/HeraldTests/BeaconPayloadDataSupplierTests.swift
@@ -13,7 +13,7 @@ class BeaconPayloadDataSupplierTests: XCTestCase {
     func testBasicFormat() throws {
         let beacon = ConcreteBeaconPayloadDataSupplierV1(countryCode: 0xDDEE, stateCode: 0x11FF, code: 0xAABBCCDD)
         let expected : Data = Data.init(base64Encoded: "MO7d/xHdzLuq")! // Hex = "30EEDDFF11DDCCBBAA"
-        let beaconPayload : Data? = beacon.payload(device: nil)
+        let beaconPayload : PayloadData? = beacon.payload(device: nil)
         XCTAssertNotNil(beaconPayload)
         XCTAssertEqual(expected.base64EncodedString(), beaconPayload!.base64EncodedString())
     }

--- a/herald/HeraldTests/DataExtensionTests.swift
+++ b/herald/HeraldTests/DataExtensionTests.swift
@@ -256,4 +256,13 @@ class DataExtensionTests: XCTestCase {
         add(attachment)
 
     }
+    
+    func testHexTransform() throws {
+        for i in 0...1000 {
+            let expected = Data(repeating: UInt8(i % 255), count: i)
+            let hex = expected.hexEncodedString()
+            let actual = Data(hexEncodedString: hex)
+            XCTAssertEqual(expected, actual)
+        }
+    }
 }

--- a/herald/HeraldTests/VenueDiaryTests.swift
+++ b/herald/HeraldTests/VenueDiaryTests.swift
@@ -169,7 +169,7 @@ class VenueDiaryTests: XCTestCase {
         XCTAssertEqual("303A03040040E20100",payload!.hexEncodedString(options: .upperCase))
         // 0x30 = 30, 826 = 3A03, 4 = 0400, 123456 = 40E20100 - LittleEndian
         
-        let brokenPayload = payload!.subdata(in: 0..<8) // too short - by 1 byte
+        let brokenPayload = PayloadData(payload!.subdata(in: 0..<8))// too short - by 1 byte
         
         let target = TargetIdentifier("SomeID")
         

--- a/herald/herald/Sensor/Analysis/VenueDiary.swift
+++ b/herald/herald/Sensor/Analysis/VenueDiary.swift
@@ -399,7 +399,7 @@ public class VenueEncounter {
         }
         // attempt to parse the payload
         // Read payload ID and version, and if we don't support it just return OK (forward compatibility)
-        let payloadIdAndVersion : UInt8 = payload[0]
+        let payloadIdAndVersion : UInt8 = payload.data[0]
         if HeraldBeaconPayloadVersions.V1.rawValue == payloadIdAndVersion {
             // default parser
         } else if (payloadIdAndVersion > HeraldBeaconPayloadVersions.V1.rawValue) && (payloadIdAndVersion <= HeraldBeaconPayloadVersions.V8.rawValue) {
@@ -410,15 +410,15 @@ public class VenueEncounter {
         logger.debug("Protocol code: \(payloadIdAndVersion), HeraldV1Beacon raw: \(HeraldBeaconPayloadVersions.V1.rawValue)")
         // If we do support it, attempt to parse
         let countryData : Data = payload.subdata(in: 1..<3) // bytes at pos 1 and 2
-        logger.debug("Country: \(countryData.hexEncodedString(options: .upperCase))")
+        logger.debug("Country: \(countryData.hexEncodedString)")
         let stateData : Data = payload.subdata(in: 3..<5) // bytes at pos 3 and 4
-        logger.debug("stateData: \(stateData.hexEncodedString(options: .upperCase))")
+        logger.debug("stateData: \(stateData.hexEncodedString)")
         let venueCodeData : Data = payload.subdata(in: 5..<9) // bytes at pos 5 and 6 and 7 and 8
-        logger.debug("venueCodeData: \(venueCodeData.hexEncodedString(options: .upperCase))")
+        logger.debug("venueCodeData: \(venueCodeData.hexEncodedString)")
         var ed : ConcreteExtendedDataV1? = nil
         var name: String? = nil
         if (payload.count > 9) {
-            ed = ConcreteExtendedDataV1(payload.subdata(in: 9..<payload.count))
+            ed = ConcreteExtendedDataV1(PayloadData(payload.subdata(in: 9..<payload.count)))
             let sections = ed!.getSections()
             for section in sections {
                 if section.code == ExtendedDataSegmentCodesV1.TextPremises.rawValue {

--- a/herald/herald/Sensor/BLE/BLEAdvertParser.swift
+++ b/herald/herald/Sensor/BLE/BLEAdvertParser.swift
@@ -1,0 +1,132 @@
+//
+//  BLEAdvertParser.swift
+//
+//  Copyright 2020 VMware, Inc.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+class BLEAdvertParser {
+    
+    static func extractSegments(_ raw: Data, _ offset: Int) -> [BLEAdvertSegment] {
+        var position = offset
+        var segments: [BLEAdvertSegment] = []
+        while (position < raw.count) {
+            if ((position + 2) <= raw.count) {
+                let segmentLength = Int(raw[position] & 0xFF)
+                position+=1
+                let segmentType = raw[position] & 0xFF
+                position+=1
+                // Note: Unsupported types are handled as 'unknown'
+                // check reported length with actual remaining data length
+                if ((position + segmentLength - 1) <= raw.count) {
+                    let segmentData = subDataBigEndian(raw, position, segmentLength - 1) // Note: type IS INCLUDED in length
+                    let rawData = Data(subDataBigEndian(raw, position - 2, segmentLength + 1))
+                    position += (segmentLength - 1)
+                    segments.append(BLEAdvertSegment(type: BLEAdvertSegmentType(rawValue: segmentType) ?? .unknown, dataLength: segmentLength - 1, data: segmentData, raw: rawData))
+                } else {
+                    // error in data length - advance to end
+                    position = raw.count
+                }
+            } else {
+                // invalid segment - advance to end
+                position = raw.count
+            }
+        }
+        return segments
+    }
+        
+    static func extractManufacturerData(segments: [BLEAdvertSegment]) -> [BLEAdvertManufacturerData] {
+        // find the manufacturerData code segment in the list
+        var manufacturerData: [BLEAdvertManufacturerData] = []
+        segments.forEach() { segment in
+            guard segment.type == .manufacturerData, segment.data.count >= 2 else {
+                return // there may be a valid segment of same type... Happens for manufacturer data
+            }
+            // Create a manufacturer data segment
+            let intValue = Int(((segment.data[1] & 0xFF) << 8) | (segment.data[0] & 0xFF))
+            manufacturerData.append(BLEAdvertManufacturerData(manufacturer: intValue, data: subDataBigEndian(segment.data,2,segment.dataLength - 2), raw: segment.raw))
+        }
+        return manufacturerData;
+    }
+
+    static func subDataBigEndian(_ raw: Data, _ offset: Int, _ length: Int) -> Data {
+        guard offset >= 0, length > 0 else {
+            return Data()
+        }
+        guard offset + length <= raw.count else {
+            return Data()
+        }
+        return raw.subdata(in: offset..<offset+length)
+    }
+
+    static func subDataLittleEndian(_ raw: Data, _ offset: Int, _ length: Int) -> Data {
+        guard offset >= 0, length > 0 else {
+            return Data()
+        }
+        guard offset + length <= raw.count else {
+            return Data()
+        }
+        return Data(raw.subdata(in: offset..<offset+length).reversed())
+    }
+}
+
+
+class BLEAdvertSegment {
+    let type: BLEAdvertSegmentType
+    let dataLength: Int
+    let data: Data // BIG ENDIAN (network order) AT THIS POINT
+    let raw: Data
+    var description: String { get {
+        return "BLEAdvertSegment{type=\(type),dataLength=\(dataLength.description),data=\(data.hexEncodedString),raw=\(raw.hexEncodedString)}"
+    }}
+
+    init(type: BLEAdvertSegmentType, dataLength: Int, data: Data, raw: Data) {
+        self.type = type
+        self.dataLength = dataLength
+        self.data = data
+        self.raw = raw
+    }
+}
+
+/// BLE Advert types - Note: We only list those we use in Herald
+/// See https://www.bluetooth.com/specifications/assigned-numbers/generic-access-profile/
+enum BLEAdvertSegmentType: UInt8 {
+    case
+    unknown = 0x00, // Valid - this number is not assigned
+    serviceUUID16IncompleteList = 0x02,
+    serviceUUID16CompleteList = 0x03,
+    serviceUUID32IncompleteList = 0x04,
+    serviceUUID32CompleteList = 0x05,
+    serviceUUID128IncompleteList = 0x06,
+    serviceUUID128CompleteList = 0x07,
+    deviceNameShortened = 0x08,
+    deviceNameComplete = 0x09,
+    txPowerLevel = 0x0A,
+    deviceClass = 0x0D,
+    simplePairingHash = 0x0E,
+    simplePairingRandomiser = 0x0F,
+    deviceID = 0x10,
+    serviceUUID16Data = 0x16,
+    meshMessage = 0x2A,
+    meshBeacon = 0x2B,
+    bigInfo = 0x2C,
+    broadcastCode = 0x2D,
+    manufacturerData = 0xFF
+}
+
+class BLEAdvertManufacturerData {
+    let manufacturer: Int
+    let data: Data // BIG ENDIAN (network order) AT THIS POINT
+    let raw: Data
+    var description: String { get {
+        return "BLEAdvertManufacturerData{manufacturer=\(manufacturer.description),data=\(data.hexEncodedString),raw=\(raw.hexEncodedString)}"
+    }}
+
+    init(manufacturer: Int, data: Data, raw: Data) {
+        self.manufacturer = manufacturer
+        self.data = data
+        self.raw = raw
+    }
+}

--- a/herald/herald/Sensor/BLE/BLESensor.swift
+++ b/herald/herald/Sensor/BLE/BLESensor.swift
@@ -30,13 +30,33 @@ public struct BLESensorConfiguration {
     /// Primary payload characteristic (read) for distributing payload data from peripheral to central, e.g. identity data
     /// - Characteristic UUID is randomly generated V4 UUIDs that has been tested for uniqueness by conducting web searches to ensure it returns no results.
     public static var payloadCharacteristicUUID = CBUUID(string: "3e98c0f8-8f05-4829-a121-43e38f8933e7")
-    public static var legacyPayloadCharacteristicUUID : CBUUID? = nil
-    /// Legacy characteristic. E.g. could be set to: CBMutableCharacteristic(type: BLESensorConfiguration.legacyPayloadCharacteristicUUID, properties: [.read, .write, .writeWithoutResponse], value: nil, permissions: [.readable, .writeable])
-    public static var legacyPayloadCharacteristic : CBMutableCharacteristic? = nil
     /// Manufacturer data is being used on Android to store pseudo device address
     /// - Pending update to dedicated ID
     public static var manufacturerIdForSensor = UInt16(65530)
 
+    
+    /// Legacy payload sharing characteristic
+    /// - Enable support for capturing of legacy read/write based protocol
+    /// - Set UUID to null to disable feature
+    /// - Example protocol is TT service that reads and writes payload via a GATT characteristic
+    /// ---- Herald will read from this characteristic to obtain legacy payload
+    /// ---- Data written to this characteristic by legacy protocol will be captured by Herald
+    public static var legacyPayloadCharacteristicUUID : CBUUID? = nil
+    /// Legacy characteristic. E.g. could be set to: CBMutableCharacteristic(type: BLESensorConfiguration.legacyPayloadCharacteristicUUID, properties: [.read, .write, .writeWithoutResponse], value: nil, permissions: [.readable, .writeable])
+    public static var legacyPayloadCharacteristic : CBMutableCharacteristic? = nil
+    /// Legacy advert only protocol service
+    /// - Enable support for capturing of legacy advert only protocols
+    /// - Assumes protocol advertises a service UUID and boardcasts token data in service data area
+    /// - Set UUID to null to disable feature
+    /// - Example protocol is EN service that uses a 16-bit UUID and data key 0xFD6F
+    /// --- Scan for 16-bit UUID by setting the value xxxx in base UUID 0000xxxx-0000-1000-8000-00805F9B34FB
+    /// --- Read broadcasted token data from service data area associated with given data key "FD6F"
+    ///     legacyAdvertOnlyProtocolServiceUUID : CBUUID? = CBUUID(string: "FD6F")
+    ///     legacyAdvertOnlyProtocolServiceUUIDDataKey : CBUUID? = CBUUID(string: "FD6F")
+    public static var legacyAdvertOnlyProtocolServiceUUID : CBUUID? = nil
+    public static var legacyAdvertOnlyProtocolServiceUUIDDataKey : CBUUID? = nil
+
+    
     // MARK:- BLE signal characteristic action codes
     
     /// Signal characteristic action code for write payload, expect 1 byte action code followed by 2 byte little-endian Int16 integer value for payload data length, then payload data

--- a/herald/herald/Sensor/BLE/BLETransmitter.swift
+++ b/herald/herald/Sensor/BLE/BLETransmitter.swift
@@ -422,18 +422,18 @@ class ConcreteBLETransmitter : NSObject, BLETransmitter, CBPeripheralManagerDele
         switch request.characteristic.uuid {
         case BLESensorConfiguration.payloadCharacteristicUUID:
             logger.debug("Read (central=\(central.description),characteristic=payload,offset=\(request.offset))")
-            let pd = payloadDataSupplier.payload(PayloadTimestamp(), device: central)
-            guard let data = pd else {
+            let payloadDataSupplied = payloadDataSupplier.payload(PayloadTimestamp(), device: central)
+            guard let payloadData = payloadDataSupplied else {
                 logger.fault("Read, no payload data supplied (central=\(central.description),characteristic=payload,offset=\(request.offset),data=BLANK)")
                 queue.async { peripheral.respond(to: request, withResult: .invalidOffset) }
                 return
             }
-            guard request.offset < data.count else {
-                logger.fault("Read, invalid offset (central=\(central.description),characteristic=payload,offset=\(request.offset),data=\(data.count))")
+            guard request.offset < payloadData.count else {
+                logger.fault("Read, invalid offset (central=\(central.description),characteristic=payload,offset=\(request.offset),data=\(payloadData.count))")
                 queue.async { peripheral.respond(to: request, withResult: .invalidOffset) }
                 return
             }
-            request.value = (request.offset == 0 ? data : data.subdata(in: request.offset..<data.count))
+            request.value = (request.offset == 0 ? payloadData.data : payloadData.subdata(in: request.offset..<payloadData.count))
             queue.async { peripheral.respond(to: request, withResult: .success) }
         default:
             logger.fault("Read (central=\(central.description),characteristic=unknown)")

--- a/herald/herald/Sensor/Extensions/DataExtensions.swift
+++ b/herald/herald/Sensor/Extensions/DataExtensions.swift
@@ -10,17 +10,26 @@ import Accelerate
 
 extension Data {
     
-    public struct HexEncodingOptions: OptionSet {
-        public init(rawValue: Int) {
-            self.rawValue = rawValue
+    var hexEncodedString: String { get {
+        return map { String(format: "%02hhX", $0) }.joined()
+    }}
+    
+    init?(hexEncodedString: String) {
+        guard hexEncodedString.count.isMultiple(of: 2) else {
+            return nil
         }
-        public let rawValue: Int
-        public static let upperCase = HexEncodingOptions(rawValue: 1 << 0)
-    }
-
-    public func hexEncodedString(options: HexEncodingOptions = []) -> String {
-        let format = options.contains(.upperCase) ? "%02hhX" : "%02hhx"
-        return map { String(format: format, $0) }.joined()
+        if hexEncodedString.count == 0 {
+            self.init()
+        } else {
+            let chars = hexEncodedString.map { $0 }
+            let bytes = stride(from: 0, to: chars.count, by: 2)
+                .map { String(chars[$0]) + String(chars[$0 + 1]) }
+                .compactMap { UInt8($0, radix: 16) }
+            guard hexEncodedString.count / bytes.count == 2 else {
+                return nil
+            }
+            self.init(bytes)
+        }
     }
     
     /// MARK:- Conversion from intrinsic types to Data
@@ -257,4 +266,12 @@ extension Data {
 /// Encoding option for string length data as prefix
 public enum StringLengthEncodingOption {
     case UINT8, UINT16, UINT32, UINT64
+}
+
+public struct HexEncodingOptions: OptionSet {
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+    public let rawValue: Int
+    public static let upperCase = HexEncodingOptions(rawValue: 1 << 0)
 }

--- a/herald/herald/Sensor/Payload/Beacon/BeaconPayloadDataSupplier.swift
+++ b/herald/herald/Sensor/Payload/Beacon/BeaconPayloadDataSupplier.swift
@@ -40,7 +40,7 @@ public class ConcreteBeaconPayloadDataSupplierV1 : BeaconPayloadDataSupplier {
         if let extended = extendedData {
             // append to payload
             if extended.hasData() {
-                fullPayload.append(extended.payload()!)
+                fullPayload.append(extended.payload()!.data)
             }
         }
         self.fullPayload = fullPayload
@@ -53,7 +53,7 @@ public class ConcreteBeaconPayloadDataSupplierV1 : BeaconPayloadDataSupplier {
     }
     
     public func payload(_ timestamp: PayloadTimestamp = PayloadTimestamp(), device: Device?) -> PayloadData? {
-        var payloadData = PayloadData()
+        let payloadData = PayloadData()
         payloadData.append(fullPayload)
         return payloadData
     }

--- a/herald/herald/Sensor/Payload/Extended/ExtendedData.swift
+++ b/herald/herald/Sensor/Payload/Extended/ExtendedData.swift
@@ -58,7 +58,7 @@ public class ConcreteExtendedDataV1 : ExtendedData {
     var payloadData : PayloadData
     
     public init() {
-        payloadData = Data() // empty
+        payloadData = PayloadData() // empty
     }
     
     public init(_ unparsedData: PayloadData) {
@@ -124,10 +124,10 @@ public class ConcreteExtendedDataV1 : ExtendedData {
                 continue
             }
             // read code
-            let code = payloadData.uint8(pos)!
+            let code = payloadData.data.uint8(pos)!
             pos = pos + 1
             // read length
-            var length = payloadData[pos]
+            var length = payloadData.data[pos]
             pos = pos + 1
             // sanity check length
             if pos + Int(length) > payloadData.count {

--- a/herald/herald/Sensor/Payload/Simple/SimplePayloadDataSupplier.swift
+++ b/herald/herald/Sensor/Payload/Simple/SimplePayloadDataSupplier.swift
@@ -96,7 +96,7 @@ public class ConcreteSimplePayloadDataSupplier : SimplePayloadDataSupplier {
     }
     
     public func payload(_ timestamp: PayloadTimestamp = PayloadTimestamp(), device: Device?) -> PayloadData? {
-        var payloadData = PayloadData()
+        let payloadData = PayloadData()
         payloadData.append(commonHeader)
         if let contactIdentifier = contactIdentifier(timestamp) {
             payloadData.append(contactIdentifier)

--- a/herald/herald/Sensor/Payload/Sonar/SonarPayloadSupplier.swift
+++ b/herald/herald/Sensor/Payload/Sonar/SonarPayloadSupplier.swift
@@ -30,7 +30,7 @@ public class MockSonarPayloadSupplier : SonarPayloadDataSupplier {
     }
     
     public func payload(_ timestamp: PayloadTimestamp = PayloadTimestamp(), device: Device?) -> PayloadData? {
-        var payloadData = PayloadData()
+        let payloadData = PayloadData()
         // First 3 bytes are reserved in SONAR
         payloadData.append(Data(repeating: 0, count: 3))
         payloadData.append(networkByteOrderData(identifier))

--- a/herald/herald/Sensor/PayloadDataSupplier.swift
+++ b/herald/herald/Sensor/PayloadDataSupplier.swift
@@ -46,17 +46,125 @@ public extension PayloadDataSupplier {
 public typealias PayloadTimestamp = Date
 
 /// Encrypted payload data received from target. This is likely to be an encrypted datagram of the target's actual permanent identifier.
-public typealias PayloadData = Data
-
-public extension PayloadData {
-    var shortName: String {
-        guard count > 0 else {
+public class PayloadData : Hashable, Equatable {
+    public var data: Data
+    public var shortName: String {
+        guard data.count > 0 else {
             return ""
         }
-        guard count > 3 else {
-            return base64EncodedString()
+        guard data.count > 3 else {
+            return data.base64EncodedString()
         }
-        return String(subdata(in: 3..<count).base64EncodedString().prefix(6))
+        return String(data.subdata(in: 3..<data.count).base64EncodedString().prefix(6))
+    }
+
+    init(_ data: Data) {
+        self.data = data
+    }
+
+    init?(base64Encoded: String) {
+        guard let data = Data(base64Encoded: base64Encoded) else {
+            return nil
+        }
+        self.data = data
+    }
+
+    init(repeating: UInt8, count: Int) {
+        self.data = Data(repeating: repeating, count: count)
+    }
+
+    init() {
+        self.data = Data()
+    }
+    
+    // MARK:- Data
+    
+    public var count: Int { get { data.count }}
+
+    public var hexEncodedString: String { get { data.hexEncodedString }}
+    
+    public func base64EncodedString() -> String {
+        return data.base64EncodedString()
+    }
+    
+    public func subdata(in range: Range<Data.Index>) -> Data {
+        return data.subdata(in: range)
+    }
+    
+    // MARK:- Hashable
+    
+    public var hashValue: Int { get { data.hashValue } }
+
+    public func hash(into hasher: inout Hasher) {
+        data.hash(into: &hasher)
+    }
+    
+    // MARK:- Equatable
+    
+    public static func ==(lhs: PayloadData, rhs: PayloadData) -> Bool {
+        return lhs.data == rhs.data
+    }
+
+    // MARK:- Append
+
+    func append(_ other: PayloadData) {
+        data.append(other.data)
+    }
+    
+    func append(_ other: Data) {
+        data.append(other)
+    }
+
+    func append(_ other: Int8) {
+        data.append(other)
+    }
+
+    func append(_ other: Int16) {
+        data.append(other)
+    }
+    
+    func append(_ other: Int32) {
+        data.append(other)
+    }
+    
+    func append(_ other: Int64) {
+        data.append(other)
+    }
+
+    func append(_ other: UInt8) {
+        data.append(other)
+    }
+
+    func append(_ other: UInt16) {
+        data.append(other)
+    }
+    
+    func append(_ other: UInt32) {
+        data.append(other)
+    }
+    
+    func append(_ other: UInt64) {
+        data.append(other)
+    }
+
+    @available(iOS 14.0, *)
+    func append(_ other: Float16) {
+        data.append(other)
+    }
+    
+    func append(_ other: Float32) {
+        data.append(other)
     }
 }
 
+/// Payload data associated with legacy service
+public class LegacyPayloadData : PayloadData {
+    public let service: String
+    
+    init(service: String, data: Data) {
+        self.service = service
+        super.init(data)
+    }
+
+    public override var shortName: String { get { super.shortName + ":L" }}
+}


### PR DESCRIPTION
- Enables payload capture from legacy advert only protocols where payload data is broadcasted in advert service data area
- Validated on iPhone X (iOS 14.2) and 6S (iOS 12.1.4) with Samsung A20 (Android 29)
- Test confirms 6S captures both Herald and Legacy payloads from A20 and iPhone X
- Normal operation for Herald protocol across all test phones

Signed-off-by: c19x <support@c19x.org>